### PR TITLE
[DBSCM-366-v10] As a packager, we need to make sure users know about Bitrock installation logs

### DIFF
--- a/server/i18n/en.lng
+++ b/server/i18n/en.lng
@@ -120,6 +120,7 @@ summary.clt.installation.directory=Command Line Tools Installation Directory
 summary.pgadmin.installation.directory=pgAdmin4 Installation Directory
 summary.sbp.installation.directory=Stack Builder Installation Directory
 summary.data.directory=Data Directory
+summary.installation.logfile=Installation Log
 summary.database.port=Database Port
 summary.database.superuser=Database Superuser
 summary.serviceaccount=Operating System Account

--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -1986,7 +1986,7 @@ EOF
                         <addTextToFile file="${installdir}${slash}installation_summary.log" insertAt="end">
                             <text>
 ${msg(summary.installation.directory)}: ${installdir}
-${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}
+${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}${msg(summary.installation.logfile)}: ${Installationlogfile}
 ===== Installation completed at: ${timestamp} =====
                             </text>
                             <ruleList>
@@ -3309,7 +3309,7 @@ ${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}
             <title>${msg(preinstall.summary)}</title>
             <explanation>${msg(preinstall.exp)}:</explanation>
             <value>${msg(summary.installation.directory)}: ${installdir}
-${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}</value>
+${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}${msg(summary.installation.logfile)}: ${Installationlogfile}</value>
             <ruleList>
                 <isFalse value="${extract_mode}"/>
             </ruleList>
@@ -3319,6 +3319,7 @@ ${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}</value>
                 <setInstallerVariable name="sbsummary" value=""/>
                 <setInstallerVariable name="dbsummary" value=""/>
                 <setInstallerVariable name="pgadminsummary" value=""/>
+                <setInstallerVariable name="Installationlogfile" value="${system_temp_directory}${slash}install-${product_shortname}.log"/>
                 <setInstallerVariable name="dbsummary" value="${msg(summary.server.installation.directory)}: ${installdir}&#10;${msg(summary.data.directory)}: ${datadir}&#10;${msg(summary.database.port)}: ${serverport}&#10;${msg(summary.database.superuser)}: ${superaccount}&#10;${msg(summary.serviceaccount)}: ${serviceaccount}&#10;${msg(summary.databaseservice)}: ${servicename}&#10;">
                     <ruleList>
                         <isTrue value="${component(server).selected}"/>


### PR DESCRIPTION
Sometimes we noticed that users who report installation fail issue don’t know where to find installation log file. So adding installation log file’s path information to the installer’s pre install summary screen and inside installation_summary.log file. This will help a user to locate the installation log file easily