### PR TITLE
Remove double quotes from PATH in pg_env.bat

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -3593,7 +3593,7 @@ export MANPATH=$MANPATH:${installdir}/share/man
                             <text>@ECHO OFF
 REM The script sets environment variables helpful for PostgreSQL
 
-@SET PATH="${installdir}\bin";%PATH%
+@SET PATH=${installdir}\bin;%PATH%
 @SET PGDATA=${datadir}
 @SET PGDATABASE=postgres
 @SET PGUSER=${superaccount}


### PR DESCRIPTION
Windows does not use double quotes in the `PATH` environment variable. Rather, the semicolon is the delimiter. If double quotes are used, attempting to run a command such as `psql.exe` will return this error:

```
could not find a "psql" to execute
```

Please see this [Server Fault question](https://serverfault.com/questions/349179/path-variable-and-quotation-marks-windows) for more details.
