### PR TITLE
PPS-561-v10: Adding support in installers to remove older version of zlib installation form macOS and linux

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -3636,5 +3636,24 @@ REM The script sets environment variables helpful for PostgreSQL
             <showMessageOnError>0</showMessageOnError>
         </deleteFile>
         <setInstallerVariable name="server_installation_done" value="1" persist="1"/>
+
+	<!-- Deleting older zlib version library -->
+        <deleteFile>
+            <path>"${installdir}/lib/libz.1.2.8.dylib"</path>
+            <ruleList>
+                <platformTest>
+                    <type>osx/type>
+                </platformTest>
+            </ruleList>
+        </deleteFile>
+	<deleteFile>
+            <path>"${installdir}/lib/libz.so.1.2.8"</path>
+            <ruleList>
+                <platformTest>
+                    <type>linux</type>
+                </platformTest>
+            </ruleList>
+        </deleteFile>
+
     </postInstallationActionList>
 </component>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -3640,20 +3640,19 @@ REM The script sets environment variables helpful for PostgreSQL
 	<!-- Deleting older zlib version library -->
         <deleteFile>
             <path>"${installdir}/lib/libz.1.2.8.dylib"</path>
+	    <ruleEvaluationLogic>or</ruleEvaluationLogic>
             <ruleList>
-                <platformTest>
-                    <type>osx/type>
-                </platformTest>
+		<compareText logic="equals" text="${installer_ui}" value="gui"/>
+		<compareText logic="equals" text="${installer_ui}" value="unattended"/>
             </ruleList>
         </deleteFile>
 	<deleteFile>
             <path>"${installdir}/lib/libz.so.1.2.8"</path>
+            <ruleEvaluationLogic>or</ruleEvaluationLogic>
             <ruleList>
-                <platformTest>
-                    <type>linux</type>
-                </platformTest>
+                <compareText logic="equals" text="${installer_ui}" value="gui"/>
+                <compareText logic="equals" text="${installer_ui}" value="unattended"/>
             </ruleList>
         </deleteFile>
-
     </postInstallationActionList>
 </component>

--- a/server/stackbuilder.xml.in
+++ b/server/stackbuilder.xml.in
@@ -297,13 +297,12 @@
 	<!-- Deleting older zlib version library -->
         <deleteFile>
             <path>"${installdir}/stackbuilder.app/Contents/Frameworks/libz.1.2.8.dylib"</path>
+            <ruleEvaluationLogic>or</ruleEvaluationLogic>
             <ruleList>
-                <platformTest>
-                    <type>osx/type>
-                </platformTest>
+                <compareText logic="equals" text="${installer_ui}" value="gui"/>
+                <compareText logic="equals" text="${installer_ui}" value="unattended"/>
             </ruleList>
         </deleteFile>
-
     </postInstallationActionList>
 
     <preUninstallationActionList>

--- a/server/stackbuilder.xml.in
+++ b/server/stackbuilder.xml.in
@@ -293,6 +293,17 @@
             </ruleList>
         </runProgram>
         <setInstallerVariable name="stackbuilder_installation_done" value="1" persist="1"/>
+
+	<!-- Deleting older zlib version library -->
+        <deleteFile>
+            <path>"${installdir}/stackbuilder.app/Contents/Frameworks/libz.1.2.8.dylib"</path>
+            <ruleList>
+                <platformTest>
+                    <type>osx/type>
+                </platformTest>
+            </ruleList>
+        </deleteFile>
+
     </postInstallationActionList>
 
     <preUninstallationActionList>


### PR DESCRIPTION
Removing libz.so.1.2.8 for REL-10