### PR TITLE
PPS-561-v11: Adding support in installers to remove older version of zlib installation for macOS 

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -3650,10 +3650,10 @@ REM The script sets environment variables helpful for PostgreSQL
 	<!-- Deleting older zlib version library -->
         <deleteFile>
             <path>"${installdir}/lib/libz.1.2.11.dylib"</path>
+            <ruleEvaluationLogic>or</ruleEvaluationLogic>
             <ruleList>
-                <platformTest>
-                    <type>osx/type>
-                </platformTest>
+		<compareText logic="equals" text="${installer_ui}" value="gui"/>
+		<compareText logic="equals" text="${installer_ui}" value="unattended"/>
             </ruleList>
         </deleteFile>
 

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2620,6 +2620,16 @@
             <persist>1</persist>
         </setInstallerVariable>
 
+	<!-- Deleting older zlib version library -->
+        <deleteFile>
+            <path>"${installdir}/lib/libz.1.2.11.dylib"</path>
+            <ruleEvaluationLogic>or</ruleEvaluationLogic>
+            <ruleList>
+		<compareText logic="equals" text="${installer_ui}" value="gui"/>
+		<compareText logic="equals" text="${installer_ui}" value="unattended"/>
+            </ruleList>
+        </deleteFile>
+
         <!-- In upgrade mode, remove the existing ldconfig setting - set during the previous installation -->
         <actionGroup>
             <actionList>
@@ -3646,16 +3656,6 @@ REM The script sets environment variables helpful for PostgreSQL
             <showMessageOnError>0</showMessageOnError>
         </deleteFile>
         <setInstallerVariable name="server_installation_done" value="1" persist="1"/>
-
-	<!-- Deleting older zlib version library -->
-        <deleteFile>
-            <path>"${installdir}/lib/libz.1.2.11.dylib"</path>
-            <ruleEvaluationLogic>or</ruleEvaluationLogic>
-            <ruleList>
-		<compareText logic="equals" text="${installer_ui}" value="gui"/>
-		<compareText logic="equals" text="${installer_ui}" value="unattended"/>
-            </ruleList>
-        </deleteFile>
 
     </postInstallationActionList>
 </component>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -3646,5 +3646,16 @@ REM The script sets environment variables helpful for PostgreSQL
             <showMessageOnError>0</showMessageOnError>
         </deleteFile>
         <setInstallerVariable name="server_installation_done" value="1" persist="1"/>
+
+	<!-- Deleting older zlib version library -->
+        <deleteFile>
+            <path>"${installdir}/lib/libz.1.2.11.dylib"</path>
+            <ruleList>
+                <platformTest>
+                    <type>osx/type>
+                </platformTest>
+            </ruleList>
+        </deleteFile>
+
     </postInstallationActionList>
 </component>

--- a/server/stackbuilder.xml.in
+++ b/server/stackbuilder.xml.in
@@ -296,6 +296,16 @@
             </ruleList>
         </runProgram>
         <setInstallerVariable name="stackbuilder_installation_done" value="1" persist="1"/>
+
+	<!-- Deleting older zlib version library -->
+        <deleteFile>
+            <path>"${installdir}/stackbuilder.app/Contents/Frameworks/libz.1.2.11.dylib"</path>
+            <ruleList>
+                <platformTest>
+                    <type>osx/type>
+                </platformTest>
+            </ruleList>
+        </deleteFile>
     </postInstallationActionList>
 
     <preUninstallationActionList>

--- a/server/stackbuilder.xml.in
+++ b/server/stackbuilder.xml.in
@@ -297,15 +297,16 @@
         </runProgram>
         <setInstallerVariable name="stackbuilder_installation_done" value="1" persist="1"/>
 
-	<!-- Deleting older zlib version library -->
+        <!-- Deleting older zlib version library -->
         <deleteFile>
             <path>"${installdir}/stackbuilder.app/Contents/Frameworks/libz.1.2.11.dylib"</path>
+            <ruleEvaluationLogic>or</ruleEvaluationLogic>
             <ruleList>
-                <platformTest>
-                    <type>osx/type>
-                </platformTest>
+                <compareText logic="equals" text="${installer_ui}" value="gui"/>
+                <compareText logic="equals" text="${installer_ui}" value="unattended"/>
             </ruleList>
         </deleteFile>
+
     </postInstallationActionList>
 
     <preUninstallationActionList>


### PR DESCRIPTION
Removing libz.so.1.2.11 for REL-11