### PR TITLE
python when linked with gettext-0.22 fails with Symbol not found: _li…

### DIFF
--- a/languagepack/build-osx.sh
+++ b/languagepack/build-osx.sh
@@ -164,15 +164,15 @@ _build_languagepack_osx() {
     
      cd $PG_PATH_OSX/languagepack/source/python.osx
  
-     export LDFLAGS="-L/opt/local/Current/lib -L\$TCL_TK_INSTALL_PATH/lib"
-     export CFLAGS="-I/opt/local/Current/include -I\$TCL_TK_INSTALL_PATH/include"
+     export LDFLAGS="-L/opt/local/Current/gettext_0.21/lib -L/opt/local/Current/lib -L\$TCL_TK_INSTALL_PATH/lib"
+     export CFLAGS="-I/opt/local/Current/gettext_0.21/include -I/opt/local/Current/include -I\$TCL_TK_INSTALL_PATH/include"
      export CPPFLAGS=\$CFLAGS
      export LD_LIBRARY_PATH="\$TCL_TK_INSTALL_PATH/lib:\$LD_LIBRARY_PATH"
      export LD_RUN_PATH="\$PYTHON_INSTALL_PATH/lib"
      export MACOSX_DEPLOYMENT_TARGET=\$MACOSX_MIN_VERSION
      export PYTHONHOME="\$PYTHON_INSTALL_PATH"
 
-     CC='clang' CFLAGS="\$PG_ARCH_OSX_CFLAGS" LDFLAGS="-L/opt/local/Current/lib \$PG_ARCH_OSX_LDFLAGS" ./configure --prefix=\$PYTHON_INSTALL_PATH --enable-shared --with-openssl=/opt/local/Current || _die "Failed to configure Python"
+     CC='clang' CFLAGS="\$PG_ARCH_OSX_CFLAGS" LDFLAGS="-L/opt/local/Current/gettext_0.21/lib -L/opt/local/Current/lib \$PG_ARCH_OSX_LDFLAGS" ./configure --prefix=\$PYTHON_INSTALL_PATH --enable-shared --with-openssl=/opt/local/Current || _die "Failed to configure Python"
      echo "-----------------------------------------------------"
      echo "out put of Python Make started"
      echo "-----------------------------------------------------"
@@ -197,7 +197,7 @@ _build_languagepack_osx() {
      echo "================end========================"
      chmod 755 \$PYTHON_INSTALL_PATH/lib/libpython*dylib
      cp -pR /opt/local/Current/lib/libiconv*dylib \$PYTHON_INSTALL_PATH/lib/
-     cp -pR /opt/local/Current/lib/libintl*dylib \$PYTHON_INSTALL_PATH/lib/
+     cp -pR /opt/local/Current/gettext_0.21/lib/libintl*dylib \$PYTHON_INSTALL_PATH/lib/
      cp -pR /opt/local/Current/lib/libssl*dylib \$PYTHON_INSTALL_PATH/lib/
      cp -pR /opt/local/Current/lib/libcrypto*dylib \$PYTHON_INSTALL_PATH/lib/
      cp -pR /opt/local/Current/lib/libz*dylib \$PYTHON_INSTALL_PATH/lib/
@@ -215,7 +215,7 @@ _build_languagepack_osx() {
      echo "============PATH Varaibles=========="
      export PYTHONHOME="\$PYTHON_INSTALL_PATH"
      export PATH="\$PYTHON_INSTALL_PATH/bin:\$PATH"
-     export LD_LIBRARY_PATH="/opt/local/Current/lib:\$LD_LIBRARY_PATH"
+     export LD_LIBRARY_PATH="/opt/local/Current/gettext_0.21/lib:/opt/local/Current/lib:\$LD_LIBRARY_PATH"
 
      python -m pip install --upgrade pip
      pip3 install --upgrade setuptools


### PR DESCRIPTION
…bintl_setlocale

Hence, build two different versions of gettext i.e one for LP and another for Postgres so adding the required changes for LP in build_osx.sh