### PR TITLE
[DBP-577]: We need to raise all of the Mac Minis to MacOS >= MacOS v1…

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -397,7 +397,7 @@ sign_binaries()
 {
         if [ ! -z $2 ]
         then
-            ENTITLEMENTS="--entitlements $2"
+            ENTITLEMENTS="--entitlements"
         fi
         security unlock-keychain -p $KEYCHAIN_PASSWD ~/Library/Keychains/login.keychain
         for i in `find $1 -type f`
@@ -406,7 +406,7 @@ sign_binaries()
            if [ $? -eq 0 ];
            then
                 echo "Signing binary $i (${ENTITLEMENTS})"
-                codesign -f -i "com.edb.postgresql" -s "Developer ID Application: EnterpriseDB Corporation" --options runtime ${ENTITLEMENTS} $i
+                codesign -f -i "com.edb.postgresql" -s "Developer ID Application: EnterpriseDB Corporation" --options runtime ${ENTITLEMENTS} $2 $i
            fi
         done
 }
@@ -416,13 +416,13 @@ sign_bundles()
 {
         if [ ! -z $2 ]
         then
-            ENTITLEMENTS="--entitlements $2"
+            ENTITLEMENTS="--entitlements"
         fi
         security unlock-keychain -p $KEYCHAIN_PASSWD ~/Library/Keychains/login.keychain
         for i in `find $1 -name "*.so"`
         do
             echo "Signing module $i (${ENTITLEMENTS})"
-            codesign -f -i "com.edb.postgresql" -s "Developer ID Application: EnterpriseDB Corporation" --options runtime ${ENTITLEMENTS}  $i
+            codesign -f -i "com.edb.postgresql" -s "Developer ID Application: EnterpriseDB Corporation" --options runtime ${ENTITLEMENTS} $2 $i
         done
 }
 
@@ -431,13 +431,13 @@ sign_libraries()
 {
         if [ ! -z $2 ]
         then
-            ENTITLEMENTS="--entitlements $2"
+            ENTITLEMENTS="--entitlements"
         fi
         security unlock-keychain -p $KEYCHAIN_PASSWD ~/Library/Keychains/login.keychain
         for i in `find $1 -type f -name "*.dylib*" -o -name "Qt*" -o -name "Python" -o -name ".Python"`
         do
             echo "Signing library $i (${ENTITLEMENTS})"
-            codesign -f -i "com.edb.postgresql" -s "Developer ID Application: EnterpriseDB Corporation" --options runtime ${ENTITLEMENTS} $i
+            codesign -f -i "com.edb.postgresql" -s "Developer ID Application: EnterpriseDB Corporation" --options runtime ${ENTITLEMENTS} $2 $i
         done
 }
 

--- a/settings.sh.in
+++ b/settings.sh.in
@@ -85,8 +85,8 @@ NODEJS_HOME="C:\\\\pgBuild64\\\\node-v18.16.0-win-x64"
 
 PG_SSH_OSX=buildfarm@battersea-park.ox.uk.enterprisedb.com
 PG_PATH_OSX=/opt/pginstaller_16.auto
-PG_SSH_OSX_SIGN=buildfarm@mors.ox.uk.enterprisedb.com
-PG_PATH_OSX_SIGN=/mnt/hgfs/pginstaller_16.auto
+PG_SSH_OSX_SIGN=buildfarm@cadwell.ox.uk.enterprisedb.com
+PG_PATH_OSX_SIGN=/Users/buildfarm/pginstaller_16.auto
 PG_PATH_OSX_SIGNTOOL=/opt/local/bin/osxsigner
 PG_SSH_OSX_NOTARY=buildfarm@cadwell.ox.uk.enterprisedb.com
 PG_PATH_OSX_NOTARY=/Users/buildfarm/pginstaller_16.notary


### PR DESCRIPTION
…2 to install the SecOpst tools.

Since mors.ox.uk used as mac signing server is of very old version so we are moving to new hardware which is cadwell.ox.uk same server that we use for notarization.