### PR TITLE
[DBP-731]: Fix for Cannot find proj.db error in postgis mac installer

### DIFF
--- a/PostGIS/build-osx.sh
+++ b/PostGIS/build-osx.sh
@@ -191,6 +191,8 @@ cat <<EOT-POSTGIS >> $WD/PostGIS/build-postgis.sh
     cp -pR /opt/local/Current_v15/lib/libpng*.*dylib staging/osx.build/PostGIS/lib || _die "Failed to copy dependent (libpng) libraries"
     cp -pR /opt/local/Current_v15/lib/libexpat*.*dylib staging/osx.build/PostGIS/lib || _die "Failed to copy dependent (expat) libraries"
     cp -pR /opt/local/Current_v15/lib/libsqlite*.*dylib staging/osx.build/PostGIS/lib || _die "Failed to copy dependent (sqlite) libraries"
+    cp -pR /opt/local/Current_v15/share/proj staging/osx.build/PostGIS/share/ || _die "Failed to copy share/proj"
+    cp -pR /opt/local/Current_v15/share/gdal staging/osx.build/PostGIS/share/ || _die "Failed to copy share/gdal"
 
     _rewrite_so_refs $PG_PATH_OSX/PostGIS/staging/osx.build/PostGIS bin @loader_path/..
     _rewrite_so_refs $PG_PATH_OSX/PostGIS/staging/osx.build/PostGIS lib @loader_path/..

--- a/PostGIS/installer.xml.in
+++ b/PostGIS/installer.xml.in
@@ -1047,6 +1047,28 @@ EOF
                 </folder>
                 <folder>
                     <description>Program Files</description>
+                    <destination>${sharedir}</destination>
+                    <name>programfilesgdalosx</name>
+                    <platforms>osx</platforms>
+                    <distributionFileList>
+                        <distributionDirectory>
+                            <origin>staging/osx/PostGIS/share/gdal</origin>
+                        </distributionDirectory>
+                    </distributionFileList>
+                </folder>
+                <folder>
+                    <description>Program Files</description>
+                    <destination>${sharedir}</destination>
+                    <name>programfilesprojosx</name>
+                    <platforms>osx</platforms>
+                    <distributionFileList>
+                        <distributionDirectory>
+                            <origin>staging/osx/PostGIS/share/proj</origin>
+                        </distributionDirectory>
+                    </distributionFileList>
+                </folder>
+                <folder>
+                    <description>Program Files</description>
                     <destination>${sharedir}/extension</destination>
                     <name>programfilesshareosxextn1</name>
                     <platforms>osx</platforms>


### PR DESCRIPTION
[DBP-731]: Fix for Cannot find proj.db error in postgis mac installer

[DBP-731]: https://enterprisedb.atlassian.net/browse/DBP-731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ