### PR TITLE
[DBP-772]: Fix issue with Chinese user and 'nt authority\system' user.

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -124,6 +124,7 @@ EOF
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>
                 </setInstallerVariableFromScriptOutput>
+		<!-- Use 'whoami' to work with "NT AUTHORITY\SYSTEM" user as 'system_username' not working-->
                 <actionGroup>
                     <actionList>
                         <generateRandomValue length="10" variable="random_number"/>
@@ -143,8 +144,32 @@ EOF
                     </actionList>
                     <ruleList>
                          <compareText logic="equals" text="${platform_name}" value="windows"/>
+			 <compareText logic="equals" text="${whoami}" value="nt authority\system"/>
                     </ruleList>
                 </actionGroup>
+		<!-- Use 'system_username' to work with normal user names and chinese user names as 'whoami' is not working with chinese users-->
+		<actionGroup>
+                    <actionList>
+                        <generateRandomValue length="10" variable="random_number"/>
+                        <createDirectory path="${system_temp_directory}/${dirPrefix}_${random_number}"/>
+                        <runProgram>
+                          <program>${env(WINDIR)}\System32\icacls</program>
+                          <programArguments>"${system_temp_directory}/${dirPrefix}_${random_number}" /inheritance:r</programArguments>
+                          <showMessageOnError>1</showMessageOnError>
+                          <progressText></progressText>
+                        </runProgram>
+                        <runProgram>
+                          <program>${env(WINDIR)}\System32\icacls</program>
+                          <programArguments>"${system_temp_directory}/${dirPrefix}_${random_number}" /T /Q /grant "${system_username}:(OI)(CI)F"</programArguments>
+                          <showMessageOnError>1</showMessageOnError>
+                        </runProgram>
+                        <setInstallerVariable name="random_number" value="${random_number}"/>
+                    </actionList>
+                    <ruleList>
+                         <compareText logic="equals" text="${platform_name}" value="windows"/>
+                         <compareText logic="does_not_equal" text="${whoami}" value="nt authority\system"/>
+                    </ruleList>
+               </actionGroup>
             </actionList>
             <parameterList>
                 <stringParameter name="dirPrefix" allowEmptyValue="0"/>


### PR DESCRIPTION
Chinese user not working with 'whoami' varaible and 'nt authority\system' user not working with 'system_username' variable.

So,Using conditions ( ${system_username} variable to handle Chinese user and {whoami} variable to handle 'nt authority\system' user ) to resolve both issues.