### PR TITLE
Update version variable name for PG source tarball

### DIFF
--- a/server/generate-sources.sh
+++ b/server/generate-sources.sh
@@ -4,11 +4,11 @@ set -xeu
 
 NAME=postgresql
 
-: ${VERSION:?The VERSION environment variable is required}
+: ${SOURCE_VERSION:?The SOURCE_VERSION environment variable is required}
 
 WORKDIR=$(pwd)/src
 cd ${WORKDIR}
-TARNAME="${NAME}-${VERSION}${EXTRA_VERSION:+.$EXTRA_VERSION}"
+TARNAME="${NAME}-${SOURCE_VERSION}"
 wget ${URL}
 md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
 mv ${TARNAME}.tar.bz2 ../

--- a/server/version.txt
+++ b/server/version.txt
@@ -1,6 +1,6 @@
 pg_major_version=17
 pg_minor_version=0
-package_revision=beta2
+package_revision=1
 pgadmin4=8.7
 python=3.12.3
 stackbuilder=4.2.1

--- a/server/version.txt
+++ b/server/version.txt
@@ -1,6 +1,6 @@
 pg_major_version=17
 pg_minor_version=0
-package_revision=1
+package_revision=beta2
 pgadmin4=8.7
 python=3.12.3
 stackbuilder=4.2.1


### PR DESCRIPTION
Updated the variable used to fetch the source version.
This variable stores the value of version according to the release type;
i.e. beta, rc, GA

DBP-872, Manika Singhal --Tested by Manika Singhal --Reviewed by Sandeep Thakkar, Srinu Perabattula, Muralikrishanan Bandaru