### PR TITLE
Build PG17 docs

### DIFF
--- a/server/resources/installation-notes.html
+++ b/server/resources/installation-notes.html
@@ -31,7 +31,7 @@
 <p>The procedural languages pl/Perl, pl/Python and pl/Tcl are included in this distribution of PostgreSQL on Windows. The server has been built using the community upstream distributions of those language interpreters. To use any of the these languages from within PostgreSQL, download and install the appropriate interpreters and ensure they are included in the PATH variable under which the database server will be started. The versions used are shown below - newer minor (bugfix) releases may also work, but have not been tested:</p>
 
 <ul>
-  <li>Perl 5.32 : https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.msi</li>
+  <li>Perl 5.38 : https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_53822_64bit/strawberry-perl-5.38.2.2-64bit-portable.zip </li>
   <li>Python 3.12 : https://www.python.org/ftp/python/3.12.3/python-3.12.3-amd64.exe </li>
   <li>Tcl 8.6 : https://sourceforge.net/projects/magicsplat/files/latest/download</li>
 </ul>

--- a/server/resources/installation-notes.html
+++ b/server/resources/installation-notes.html
@@ -28,15 +28,15 @@
 
 <h3>Procedural Languages</h3>
 
-<p>The procedural languages pl/Perl, pl/Python and pl/Tcl are included in this distribution of PostgreSQL. The server has been built using the LanguagePack community distributions of those language interpreters. To use any of the these languages from within PostgreSQL, download and install the appropriate interpreters and ensure they are included in the PATH variable under which the database server will be started. The versions used are shown below - newer minor (bugfix) releases may also work, but have not been tested:</p>
+<p>The procedural languages pl/Perl, pl/Python and pl/Tcl are included in this distribution of PostgreSQL on Windows. The server has been built using the community upstream distributions of those language interpreters. To use any of the these languages from within PostgreSQL, download and install the appropriate interpreters and ensure they are included in the PATH variable under which the database server will be started. The versions used are shown below - newer minor (bugfix) releases may also work, but have not been tested:</p>
 
 <ul>
-  <li>Perl 5.38</li>
-  <li>Python 3.11</li>
-  <li>Tcl 8.6</li>
+  <li>Perl 5.32 : https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.msi</li>
+  <li>Python 3.12 : https://www.python.org/ftp/python/3.12.3/python-3.12.3-amd64.exe </li>
+  <li>Tcl 8.6 : https://sourceforge.net/projects/magicsplat/files/latest/download</li>
 </ul>
 
-<p>The current pl/Python is dynamically linked with Python's shared library in the LanguagePack v4.x installers. Some distributions of Python interpreters (including ActivePython) on Linux do not carry a dynamic library of Python. Such interpreters would no longer be functional with pl/Python.We strongly recommend the users to use LanguagePack installers for pl/Perl, pl/Python and pl/Tcl. The beta installers might see plperl extension failing on x86_64 architecture</p>
+<p>The current pl/Python is dynamically linked with Python's shared library in the LanguagePack v4.x installers. Some distributions of Python interpreters (including ActivePython) on Linux do not carry a dynamic library of Python. Such interpreters would no longer be functional with pl/Python.We strongly recommend the users to use LanguagePack installers for pl/Perl, pl/Python and pl/Tcl on macOS.</p>
 
 <h3>pl/pgsql Debugger</h3>
 

--- a/server/scripts/windows/compile.ps1
+++ b/server/scripts/windows/compile.ps1
@@ -167,13 +167,12 @@ Set-Acl $temporary_data_location $Acl
 
 
 # So far, so good. Let's start compiling
-#Write-Host "Executing meson bat file"
-#Start-Process -FilePath packaging-config/server/scripts/windows/meson.bat -Wait -NoNewWindow
+Write-Host "Executing meson bat file"
+Start-Process -FilePath packaging-config/server/scripts/windows/meson.bat -Wait -NoNewWindow
 
 Write-Host " Executing Doc Script "
 C:\msys64\usr\bin\sh.exe packaging-config/server/scripts/windows/meson-doc.sh
 Write-Host "Meson doc Script execution completed"
-exit 1
 
 Write-Host "copying meson-install content to $installation_directory"
 Copy-Item -Path "$source_directory\meson-install\*" -Destination $installation_directory/ -Recurse

--- a/server/scripts/windows/compile.ps1
+++ b/server/scripts/windows/compile.ps1
@@ -167,8 +167,13 @@ Set-Acl $temporary_data_location $Acl
 
 
 # So far, so good. Let's start compiling
-Write-Host "Executing meson bat file"
-Start-Process -FilePath packaging-config/server/scripts/windows/meson.bat -Wait -NoNewWindow
+#Write-Host "Executing meson bat file"
+#Start-Process -FilePath packaging-config/server/scripts/windows/meson.bat -Wait -NoNewWindow
+
+Write-Host " Executing Doc Script "
+C:\msys64\usr\bin\sh.exe packaging-config/server/scripts/windows/meson-doc.sh
+Write-Host "Meson doc Script execution completed"
+exit 1
 
 Write-Host "copying meson-install content to $installation_directory"
 Copy-Item -Path "$source_directory\meson-install\*" -Destination $installation_directory/ -Recurse

--- a/server/scripts/windows/meson-doc.sh
+++ b/server/scripts/windows/meson-doc.sh
@@ -8,11 +8,11 @@ pacman -S docbook-xml docbook-xsl
 
 export PATH=/C/hostedtoolcache/windows/Python/3.12.3/x64:/C/hostedtoolcache/windows/Python/3.12.3/x64/Scripts:$PATH
 
-mkdir /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc
+mkdir /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3/meson-build-doc
 
-meson setup /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2 /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc --prefix=/D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build/meson-install
+meson setup /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3 /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3/meson-build-doc --prefix=/D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3/meson-build/meson-install
 
-cd /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc
+cd /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3/meson-build-doc
 ninja docs
-mv /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc/doc /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-install/
-ls -l /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-install/doc/src/sgml/html/a*.html
+mv /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3/meson-build-doc/doc /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3/meson-install/
+ls -l /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta3/meson-install/doc/src/sgml/html/a*.html

--- a/server/scripts/windows/meson-doc.sh
+++ b/server/scripts/windows/meson-doc.sh
@@ -17,5 +17,5 @@ meson setup /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation
 
 cd /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc
 ninja docs
-ls -l /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc/doc/src/sgml/html/a*.html
-
+mv /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc/doc /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-install/
+ls -l /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-install/doc/src/sgml/html/a*.html

--- a/server/scripts/windows/meson-doc.sh
+++ b/server/scripts/windows/meson-doc.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+echo "==== Installing libxml2 and libxslt using pacman ===="
+pacman -S libxml2 libxslt
+
+echo "==== Installing docbook-xml and docbook-xsl using pacman ===="
+pacman -S docbook-xml docbook-xsl
+
+export PATH=/C/hostedtoolcache/windows/Python/3.12.3/x64:/C/hostedtoolcache/windows/Python/3.12.3/x64/Scripts:$PATH
+
+mkdir /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc
+
+meson setup /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2 /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc --prefix=/D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build/meson-install
+
+cd /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc
+ninja docs
+ls -l /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc/doc/src/sgml/html/a*.html
+

--- a/server/scripts/windows/meson-doc.sh
+++ b/server/scripts/windows/meson-doc.sh
@@ -6,6 +6,9 @@ pacman -S libxml2 libxslt
 echo "==== Installing docbook-xml and docbook-xsl using pacman ===="
 pacman -S docbook-xml docbook-xsl
 
+echo "==== Rename the link.exe ===="
+mv /c/msys64/usr/bin/link.exe /c/msys64/usr/bin/link.exe_bk
+
 export PATH=/C/hostedtoolcache/windows/Python/3.12.3/x64:/C/hostedtoolcache/windows/Python/3.12.3/x64/Scripts:$PATH
 
 mkdir /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc

--- a/server/scripts/windows/meson-doc.sh
+++ b/server/scripts/windows/meson-doc.sh
@@ -6,9 +6,6 @@ pacman -S libxml2 libxslt
 echo "==== Installing docbook-xml and docbook-xsl using pacman ===="
 pacman -S docbook-xml docbook-xsl
 
-echo "==== Rename the link.exe ===="
-mv /c/msys64/usr/bin/link.exe /c/msys64/usr/bin/link.exe_bk
-
 export PATH=/C/hostedtoolcache/windows/Python/3.12.3/x64:/C/hostedtoolcache/windows/Python/3.12.3/x64/Scripts:$PATH
 
 mkdir /D/a/postgresql-packaging-foundation/postgresql-packaging-foundation/postgresql-17beta2/meson-build-doc

--- a/server/scripts/windows/meson.bat
+++ b/server/scripts/windows/meson.bat
@@ -12,8 +12,7 @@ SET BASE_PATH=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundati
 SET
 PATH=C:\hostedtoolcache\windows\Python\3.12.3\x64;C:\hostedtoolcache\windows\Python\3.12.3\x64\Scripts;%BASE_PATH%\pkg-config-lite-0.28-1\bin;%BASE_PATH%\strawberry-perl-5.38.2.2-64bit-portable\perl\bin;%BASE_PATH%\openssl\bin;%BASE_PATH%\zlib\bin;%BASE_PATH%\libxml2\bin;%BASE_PATH%\zstd\bin;%BASE_PATH%\1z4\bin;%BASE_PATH%\libxslt\bin;%BASE_PATH%\icu\bin;%PATH%
 
-SET
-PKG_CONFIG_PATH=%BASE_PATH%\zlib\lib\pkgconfig;%BASE_PATH%\libxml2\lib\pkgconfig;%BASE_PATH%\zstd\lib\pkgconfig;%BASE_PATH%\lz4\lib\pkgconfig;%BASE_PATH%\libxslt\lib\pkgconfig;%BASE_PATH%\icu\lib64\pkgconfig;C:\Users\runneradmin\AppData\Local\Apps\Tcl86\lib\pkgconfig;%BASE_PATH%\uuid\lib\pkgconfig
+SET PKG_CONFIG_PATH=%BASE_PATH%\zlib\lib\pkgconfig;%BASE_PATH%\libxml2\lib\pkgconfig;%BASE_PATH%\zstd\lib\pkgconfig;%BASE_PATH%\lz4\lib\pkgconfig;%BASE_PATH%\libxslt\lib\pkgconfig;%BASE_PATH%\icu\lib64\pkgconfig;C:\Users\runneradmin\AppData\Local\Apps\Tcl86\lib\pkgconfig;%BASE_PATH%\uuid\lib\pkgconfig
 
 meson setup D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2 D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-build --prefix=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-install -Dnls=enabled -Duuid=ossp -Dplperl=enabled -Dssl=openssl -Dextra_include_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\include,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\include -Dextra_lib_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\lib,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\lib
 

--- a/server/scripts/windows/meson.bat
+++ b/server/scripts/windows/meson.bat
@@ -9,7 +9,8 @@ mkdir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postg
 
 SET BASE_PATH=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation
 
-SET PATH=C:\hostedtoolcache\windows\Python\3.12.3\x64;C:\hostedtoolcache\windows\Python\3.12.3\x64\Scripts;%BASE_PATH%\pkg-config-lite-0.28-1\bin;C:\Strawberry\perl\bin;%BASE_PATH%\openssl\bin;%BASE_PATH%\zlib\bin;%BASE_PATH%\libxml2\bin;%BASE_PATH%\zstd\bin;%BASE_PATH%\1z4\bin;%BASE_PATH%\libxslt\bin;%BASE_PATH%\icu\bin;%PATH%
+SET
+PATH=C:\hostedtoolcache\windows\Python\3.12.3\x64;C:\hostedtoolcache\windows\Python\3.12.3\x64\Scripts;%BASE_PATH%\pkg-config-lite-0.28-1\bin;%BASE_PATH%\strawberry-perl-5.38.2.2-64bit-portable\perl\bin;%BASE_PATH%\openssl\bin;%BASE_PATH%\zlib\bin;%BASE_PATH%\libxml2\bin;%BASE_PATH%\zstd\bin;%BASE_PATH%\1z4\bin;%BASE_PATH%\libxslt\bin;%BASE_PATH%\icu\bin;%PATH%
 
 SET PKG_CONFIG_PATH=%BASE_PATH%\zlib\lib\pkgconfig;%BASE_PATH%\libxml2\lib\pkgconfig;%BASE_PATH%\zstd\lib\pkgconfig;%BASE_PATH%\lz4\lib\pkgconfig;%BASE_PATH%\libxslt\lib\pkgconfig;%BASE_PATH%\icu\lib\pkgconfig;C:\Users\runneradmin\AppData\Local\Apps\Tcl86\lib\pkgconfig;%BASE_PATH%\uuid\lib\pkgconfig
 

--- a/server/scripts/windows/meson.bat
+++ b/server/scripts/windows/meson.bat
@@ -12,7 +12,8 @@ SET BASE_PATH=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundati
 SET
 PATH=C:\hostedtoolcache\windows\Python\3.12.3\x64;C:\hostedtoolcache\windows\Python\3.12.3\x64\Scripts;%BASE_PATH%\pkg-config-lite-0.28-1\bin;%BASE_PATH%\strawberry-perl-5.38.2.2-64bit-portable\perl\bin;%BASE_PATH%\openssl\bin;%BASE_PATH%\zlib\bin;%BASE_PATH%\libxml2\bin;%BASE_PATH%\zstd\bin;%BASE_PATH%\1z4\bin;%BASE_PATH%\libxslt\bin;%BASE_PATH%\icu\bin;%PATH%
 
-SET PKG_CONFIG_PATH=%BASE_PATH%\zlib\lib\pkgconfig;%BASE_PATH%\libxml2\lib\pkgconfig;%BASE_PATH%\zstd\lib\pkgconfig;%BASE_PATH%\lz4\lib\pkgconfig;%BASE_PATH%\libxslt\lib\pkgconfig;%BASE_PATH%\icu\lib\pkgconfig;C:\Users\runneradmin\AppData\Local\Apps\Tcl86\lib\pkgconfig;%BASE_PATH%\uuid\lib\pkgconfig
+SET
+PKG_CONFIG_PATH=%BASE_PATH%\zlib\lib\pkgconfig;%BASE_PATH%\libxml2\lib\pkgconfig;%BASE_PATH%\zstd\lib\pkgconfig;%BASE_PATH%\lz4\lib\pkgconfig;%BASE_PATH%\libxslt\lib\pkgconfig;%BASE_PATH%\icu\lib64\pkgconfig;C:\Users\runneradmin\AppData\Local\Apps\Tcl86\lib\pkgconfig;%BASE_PATH%\uuid\lib\pkgconfig
 
 meson setup D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2 D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-build --prefix=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-install -Dnls=enabled -Duuid=ossp -Dplperl=enabled -Dssl=openssl -Dextra_include_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\include,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\include -Dextra_lib_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\lib,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\lib
 

--- a/server/scripts/windows/meson.bat
+++ b/server/scripts/windows/meson.bat
@@ -4,8 +4,8 @@ CALL "C:\\Program Files\\Microsoft Visual Studio\\2022\Enterprise\VC\Auxiliary\B
 
 ECHO Creating build and install dirs...
 
-mkdir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-build
-mkdir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-install
+mkdir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta3\meson-build
+mkdir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta3\meson-install
 
 SET BASE_PATH=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation
 
@@ -14,12 +14,12 @@ PATH=C:\hostedtoolcache\windows\Python\3.12.3\x64;C:\hostedtoolcache\windows\Pyt
 
 SET PKG_CONFIG_PATH=%BASE_PATH%\zlib\lib\pkgconfig;%BASE_PATH%\libxml2\lib\pkgconfig;%BASE_PATH%\zstd\lib\pkgconfig;%BASE_PATH%\lz4\lib\pkgconfig;%BASE_PATH%\libxslt\lib\pkgconfig;%BASE_PATH%\icu\lib64\pkgconfig;C:\Users\runneradmin\AppData\Local\Apps\Tcl86\lib\pkgconfig;%BASE_PATH%\uuid\lib\pkgconfig
 
-meson setup D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2 D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-build --prefix=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-install -Dnls=enabled -Duuid=ossp -Dplperl=enabled -Dssl=openssl -Dextra_include_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\include,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\include -Dextra_lib_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\lib,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\lib
+meson setup D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta3 D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta3\meson-build --prefix=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta3\meson-install -Dnls=enabled -Duuid=ossp -Dplperl=enabled -Dssl=openssl -Dextra_include_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\include,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\include -Dextra_lib_dirs=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\gettext\lib,D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\openssl\lib
 
-cd D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-build
+cd D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta3\meson-build
 ECHO meson build dir content
 dir
 ninja --verbose
 
 ninja install
-dir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta2\meson-install
+dir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postgresql-17beta3\meson-install

--- a/server/scripts/windows/meson.bat
+++ b/server/scripts/windows/meson.bat
@@ -9,7 +9,7 @@ mkdir D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation\postg
 
 SET BASE_PATH=D:\a\postgresql-packaging-foundation\postgresql-packaging-foundation
 
-SET PATH=%BASE_PATH%\pkg-config-lite-0.28-1\bin;C:\Strawberry\perl\bin;%BASE_PATH%\openssl\bin;%BASE_PATH%\zlib\bin;%BASE_PATH%\libxml2\bin;%BASE_PATH%\zstd\bin;%BASE_PATH%\1z4\bin;%BASE_PATH%\libxslt\bin;%BASE_PATH%\icu\bin;%PATH%
+SET PATH=C:\hostedtoolcache\windows\Python\3.12.3\x64;C:\hostedtoolcache\windows\Python\3.12.3\x64\Scripts;%BASE_PATH%\pkg-config-lite-0.28-1\bin;C:\Strawberry\perl\bin;%BASE_PATH%\openssl\bin;%BASE_PATH%\zlib\bin;%BASE_PATH%\libxml2\bin;%BASE_PATH%\zstd\bin;%BASE_PATH%\1z4\bin;%BASE_PATH%\libxslt\bin;%BASE_PATH%\icu\bin;%PATH%
 
 SET PKG_CONFIG_PATH=%BASE_PATH%\zlib\lib\pkgconfig;%BASE_PATH%\libxml2\lib\pkgconfig;%BASE_PATH%\zstd\lib\pkgconfig;%BASE_PATH%\lz4\lib\pkgconfig;%BASE_PATH%\libxslt\lib\pkgconfig;%BASE_PATH%\icu\lib\pkgconfig;C:\Users\runneradmin\AppData\Local\Apps\Tcl86\lib\pkgconfig;%BASE_PATH%\uuid\lib\pkgconfig
 


### PR DESCRIPTION
Build the PG17 docs using meson-doc.sh script as we can’t build the docs on windows.

Update installation-notes to use procedural languages pl/Perl,
pl/Python and pl/Tcl from community upstream for windows.

Use strawberry-perl 5.38