### PR TITLE
Removing debug-symbols from bin and lib directory for PG17 in upgrade mode.

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -2060,7 +2060,7 @@ ${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}${msg(summary.installation
             </actionList>
             <ruleList>
                 <compareText text="${platform_name}" logic="contains" value="windows" />
-                <compareVersions logic="less_or_equal" version1="${brandingVer}" version2="17.1-1" />
+                <compareVersions logic="equals" version1="${brandingVer}" version2="17.0-1" />
                 <isTrue value="${IsUpgrade}"/>
             </ruleList>
         </actionGroup>

--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -2052,6 +2052,18 @@ ${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}${msg(summary.installation
                 <isFalse value="${extract_mode}"/>
             </ruleList>
         </actionGroup>
+
+        <actionGroup>
+            <actionList>
+                <deleteFile path="${installdir}${slash}bin${slash}*.pdb" />
+                <deleteFile path="${installdir}${slash}lib${slash}*.pdb" />
+            </actionList>
+            <ruleList>
+                <compareText text="${platform_name}" logic="contains" value="windows" />
+                <compareVersions logic="less_or_equal" version1="${brandingVer}" version2="17.1-1" />
+                <isTrue value="${IsUpgrade}"/>
+            </ruleList>
+        </actionGroup>
     </postInstallationActionList>
 
     <!-- Components. Most components will be separate packages, so expect just one entry here most of the time -->

--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -2060,7 +2060,7 @@ ${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}${msg(summary.installation
             </actionList>
             <ruleList>
                 <compareText text="${platform_name}" logic="contains" value="windows" />
-                <compareVersions logic="equals" version1="${brandingVer}" version2="17.0-1" />
+                <compareVersions logic="less_or_equal" version1="${brandingVer}" version2="17.0-1" />
                 <isTrue value="${IsUpgrade}"/>
             </ruleList>
         </actionGroup>


### PR DESCRIPTION
PG17 has debug-symbols bundled in bin and lib directory,
unlike we do for back branches.
So, removing them in upgrade mode.
We will keep a separate archive for symbols now and that will be done in a separate PR.

--Manika Singhal, Reviewed by --Sandeep Thakkar