### PR TITLE
Discontinue to bundle debug-symbols in PG installers and their binaries.

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -173,9 +173,6 @@
                 <distributionDirectory>
                     <origin>staging/@@WINDIR@@/server/share</origin>
                 </distributionDirectory>
-                <distributionDirectory>
-                    <origin>staging/@@WINDIR@@/server/debug_symbols</origin>
-                </distributionDirectory>
                 <distributionFile>
                     <origin>staging/@@WINDIR@@/server/server_license.txt</origin>
                 </distributionFile>

--- a/server/scripts/windows/prepare-staging-directory.sh
+++ b/server/scripts/windows/prepare-staging-directory.sh
@@ -6,7 +6,6 @@ mkdir -p packaging-config/installer/server/staging/windows-x64/server
 mkdir -p packaging-config/installer/server/staging/windows-x64/server/bin
 mkdir -p packaging-config/installer/server/staging/windows-x64/server/lib
 mkdir -p packaging-config/installer/server/staging/windows-x64/server/share/extension
-mkdir -p packaging-config/installer/server/staging/windows-x64/server/debug_symbols
 mkdir -p packaging-config/installer/server/staging/windows-x64/scripts
 mkdir -p packaging-config/installer/server/staging/windows-x64/resources
 cp -R packaging-config/resources/license.txt packaging-config/installer/server/staging/windows-x64/server/server_license.txt
@@ -45,7 +44,6 @@ cp -R "$VCToolsRedistDir"vc_redist.x64.exe packaging-config/installer/server/sta
 cp -R pgsql/doc packaging-config/installer/server/staging/windows-x64/server
 cp -R packaging-config/server/resources/installation-notes.html packaging-config/installer/server/staging/windows-x64/server/doc
  
-cp -r pgsql/symbols/* packaging-config/installer/server/staging/windows-x64/server/debug_symbols
 cp -r packaging-config/server/scripts/windows/getlocales/x64/Release/getlocales.exe packaging-config/installer/server/staging/windows-x64/server/installer/server/getlocales.exe
 cp -r packaging-config/server/scripts/windows/validateuser/x64/Release/validateuser.exe packaging-config/installer/server/staging/windows-x64/server/installer/server/validateuser.exe
 cp -r packaging-config/server/scripts/windows/createuser/x64/Release/createuser.exe packaging-config/installer/server/staging/windows-x64/server/installer/server/createuser.exe


### PR DESCRIPTION
Historically, we are bundling *.pdb files in our PG installers binaries zip and exe files. 
But now we are reconsidering it, given there size is increasing 
like in PG15 size was ~110MB and on PG17 size is ~158MB.
So, we are discontinuing to bundle them with installer and binaries. 
We maintain a separate archive of .pdb files and keep that on CS instead, 
so if any customer demands for it we can always share it with them.
In EPAS, we are following this later way.

--Manika Singhal --Reviewed by --Sandeep Thakkar, Srinu Perabattula