### PR TITLE
delete debug_symbols directory in upgrade mode.

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -2057,6 +2057,16 @@ ${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}${msg(summary.installation
             <actionList>
                 <deleteFile path="${installdir}${slash}bin${slash}*.pdb" />
                 <deleteFile path="${installdir}${slash}lib${slash}*.pdb" />
+                <deleteFile path="${installdir}${slash}lib${slash}pgxs">
+                    <ruleList>
+                        <fileExists path="${installdir}${slash}pgxs" />
+                    </ruleList>
+                </deleteFile>
+                <deleteFile path="${installdir}${slash}debug_symbols">
+                    <ruleList>
+                        <fileExists path="${installdir}${slash}debug_symbols" />
+                    </ruleList>
+                </deleteFile>
             </actionList>
             <ruleList>
                 <compareText text="${platform_name}" logic="contains" value="windows" />

--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -2057,11 +2057,6 @@ ${dbsummary}${cltsummary}${pgadminsummary}${sbsummary}${msg(summary.installation
             <actionList>
                 <deleteFile path="${installdir}${slash}bin${slash}*.pdb" />
                 <deleteFile path="${installdir}${slash}lib${slash}*.pdb" />
-                <deleteFile path="${installdir}${slash}lib${slash}pgxs">
-                    <ruleList>
-                        <fileExists path="${installdir}${slash}pgxs" />
-                    </ruleList>
-                </deleteFile>
                 <deleteFile path="${installdir}${slash}debug_symbols">
                     <ruleList>
                         <fileExists path="${installdir}${slash}debug_symbols" />


### PR DESCRIPTION
delete debug_symbols directory in upgrade mode.

--Manika Singhal, Reviewed by --Sandeep Thakkar, Srinu Perabattula