### PR TITLE
Update installer XML: Replace "NT AUTHORITY\SYSTEM" with it's SID

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -124,6 +124,23 @@ EOF
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>
                 </setInstallerVariableFromScriptOutput>
+                <showInfo>
+                    <text>${whoami}</text>
+                </showInfo>
+                <!-- Windows: System account SID -->
+                <runProgram>
+                    <program>whoami</program>
+                     <programArguments>/USER /nh</programArguments>
+                </runProgram>
+                <setInstallerVariableFromRegEx>
+                    <name>whoami_sid</name>
+                    <pattern>^.*\s+(S-[0-9-]+)\s*$</pattern>
+                    <substitution>\1</substitution>
+                    <text>${program_stdout}</text>
+                </setInstallerVariableFromRegEx>
+                <showInfo>
+                    <text>${whoami_sid}</text>
+                </showInfo>
 		<!-- Use 'whoami' to work with "NT AUTHORITY\SYSTEM" user as 'system_username' not working-->
 		 <actionGroup>
                     <actionList>
@@ -144,7 +161,7 @@ EOF
                     </actionList>
                     <ruleList>
                          <compareText logic="equals" text="${platform_name}" value="windows"/>
-			 <compareText logic="equals" text="${whoami}" value="nt authority\system"/>
+			 <compareText logic="equals" text="${whoami_sid}" value="S-1-5-18"/>
                     </ruleList>
                 </actionGroup>
                 <!-- Use 'system_username' to work with local administrator accounts -->
@@ -167,7 +184,7 @@ EOF
                     </actionList>
                     <ruleList>
                          <compareText logic="equals" text="${platform_name}" value="windows"/>
-                         <compareText logic="does_not_equal" text="${whoami}" value="nt authority\system"/>
+                         <compareText logic="does_not_equal" text="${whoami_sid}" value="S-1-5-18"/>
                     </ruleList>
                </actionGroup>
             </actionList>

--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -124,10 +124,10 @@ EOF
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>
                 </setInstallerVariableFromScriptOutput>
-                <showInfo>
-                    <text>${whoami}</text>
-                </showInfo>
-                <!-- Windows: System account SID -->
+                <logMessage>
+                    <text>"whoami: ${whoami}"</text>
+                </logMessage>
+                <!-- Windows: System account SID so that ruleList works for non-English language -->
                 <runProgram>
                     <program>whoami</program>
                      <programArguments>/USER /nh</programArguments>
@@ -138,9 +138,10 @@ EOF
                     <substitution>\1</substitution>
                     <text>${program_stdout}</text>
                 </setInstallerVariableFromRegEx>
-                <showInfo>
-                    <text>${whoami_sid}</text>
-                </showInfo>
+                <logMessage>
+                    <text>"whoami_sid: ${whoami_sid}"</text>
+                </logMessage>
+
 		<!-- Use 'whoami' to work with "NT AUTHORITY\SYSTEM" user as 'system_username' not working-->
 		 <actionGroup>
                     <actionList>

--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -129,7 +129,7 @@ EOF
                 </logMessage>
                 <!-- Windows: System account SID so that ruleList works for non-English language -->
                 <runProgram>
-                    <program>whoami</program>
+                    <program>${env(WINDIR)}\System32\whoami</program>
                      <programArguments>/USER /nh</programArguments>
                 </runProgram>
                 <setInstallerVariableFromRegEx>

--- a/server/version.txt
+++ b/server/version.txt
@@ -1,6 +1,6 @@
 pg_major_version=17
 pg_minor_version=2
-package_revision=1
+package_revision=2
 pgadmin4=8.13
 python=3.12.7
 perl=5.40.0.1


### PR DESCRIPTION
The usage of "NT AUTHORITY\SYSTEM" doesn't work on the
system with non-English languages. Hence, use the Security
Identifier (SID) for the local system account instead

