### PR TITLE
Installation issue in WinRM session

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -155,6 +155,7 @@ EOF
                         <setWindowsACL>
                             <action>allow</action>
                             <files>${system_temp_directory}/${dirPrefix}_${random_number}</files>
+                            <recurseObjects>1</recurseObjects>
                             <permissions>generic_all</permissions>
                             <users>${whoami}</users>
                         </setWindowsACL>
@@ -178,6 +179,7 @@ EOF
                         <setWindowsACL>
                             <action>allow</action>
                             <files>${system_temp_directory}/${dirPrefix}_${random_number}</files>
+                            <recurseObjects>1</recurseObjects>
                             <permissions>generic_all</permissions>
                             <users>${env(USERDOMAIN)}\${system_username}</users>
                         </setWindowsACL>


### PR DESCRIPTION
As reported by few users, installation fails when the installer is run remotely 
through WinRM or remote powershell, because initdb fails to read the password file.
The password file is created inside the temporary directory which is 
created with the locked down ACLs but it seems it is not applied to the object descendant. 
Hence, enable recurseObjects in the <setWindowsACL> action to fix the issue.
For local installation, the logon session ID (NT AUTHORITY\LogonSessionId_0_2173841:(RX)) 
allowed the read access to the password file.

DBP-939: PostgreSQL installer does not work over a WinRM session
-- Manika Singhal, Tested by- Manika Singhal, Reviewed by- Sandeep Thakkar