### PR TITLE
fix the command for file path containing white spaces.

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2031,7 +2031,7 @@
                 <!--Get the list of locales in the format BCP-47_Code=English_Name-->
                 <setInstallerVariable>
                     <name>localeCommand</name>
-                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 }  | Sort-Object EnglishName | ForEach-Object { $_.Name + '=' + $_.EnglishName } | Out-File -FilePath "${system_temp_directory}/postgresql_installer_${random_number}/locales.txt" -Encoding UTF8</value>
+                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 }  | Sort-Object EnglishName | ForEach-Object { $_.Name + '=' + $_.EnglishName } | Out-File -FilePath \"${system_temp_directory}/postgresql_installer_${random_number}/locales.txt\" -Encoding UTF8</value>
                 </setInstallerVariable>
                 
                 <runProgram>


### PR DESCRIPTION
the command was failing if the path of the Out-File contains
white spaces. Escaped the quotes to treat the full path as a single
string whether or not it contains any number of white spaces.

edb-installers issues: #255, #259, #257, #261  --Manika Singhal