### PR TITLE
fix installation failure when Windows username contains non-ASCII characters

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2031,7 +2031,7 @@
                 <!--Get the list of locales in the format BCP-47_Code=English_Name-->
                 <setInstallerVariable>
                     <name>localeCommand</name>
-                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 }  | Sort-Object EnglishName | ForEach-Object { $_.Name + '=' + $_.EnglishName } | Out-File -FilePath \"${system_temp_directory}/postgresql_installer_${random_number}/locales.txt\" -Encoding UTF8</value>
+                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 }  | Sort-Object EnglishName | ForEach-Object { $_.Name + '=' + $_.EnglishName } | Out-File -FilePath \"${env(TEMP)}/postgresql_installer_${random_number}/locales.txt\" -Encoding UTF8</value>
                 </setInstallerVariable>
                 
                 <runProgram>
@@ -2045,13 +2045,13 @@
                 
                 <readFile>
                     <name>program_stdout</name>
-                    <path>${system_temp_directory}\postgresql_installer_${random_number}\locales.txt</path>
+                    <path>${env(TEMP)}\postgresql_installer_${random_number}\locales.txt</path>
                     <encoding>utf-8</encoding>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>
                 </readFile>
-                <deleteFile path="${system_temp_directory}\postgresql_installer_${random_number}\locales.txt"/>
+                <deleteFile path="${env(TEMP)}\postgresql_installer_${random_number}\locales.txt"/>
 
                 <throwError>
                     <text>${msg(script.command.line.error)}</text>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2934,7 +2934,7 @@
 
                         <runProgram>
                             <program>${env(WINDIR)}\System32\cmd.exe</program>
-                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${superpassword.password}" "${system_temp_directory}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
+                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${superpassword.password}" "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
                             <progressText>${msg(progress.text.initialising.cluster)}</progressText>
                             <abortOnError>0</abortOnError>
                             <showMessageOnError>0</showMessageOnError>

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -235,7 +235,7 @@ $passwordFile = Join-Path "$PasswordDir"  $randomFileName
 Set-Content -Path "$passwordFile" -Value $Password -Force
 
 # Set initdb command to be executed
-$initdbCmd = "`"$InstallDir\\bin\\initdb.exe`" --pgdata=`"$DataDir`" --username=`"$SuperUsername`" --encoding=UTF8 --locale=`"$Locale`" --pwfile=`"$passwordFile`" --auth=scram-sha-256"
+$initdbCmd = "& `"$InstallDir\\bin\\initdb.exe`" --pgdata=`"$DataDir`" --username=`"$SuperUsername`" --encoding=UTF8 --locale=`"$Locale`" --pwfile=`"$passwordFile`" --auth=scram-sha-256"
 
 # Run initdb
 Write-Host "`nInitializing PostgreSQL database cluster..."

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -15,7 +15,7 @@ param (
 
 # Validate input arguments
 if (-not $OSUsername -or -not $SuperUsername -or -not $Password -or -not $PasswordDir -or -not $InstallDir -or -not $DataDir -or -not $Port -or -not $Locale -or -not $CheckACL) {
-    Write-Host "Usage: initcluster.vbs <OSUsername> <SuperUsername> <Password> <PasswordDir> <Install dir> <Data dir> <Port> <Locale> <CheckACL>"
+    Write-Host "Usage: initcluster.ps1 <OSUsername> <SuperUsername> <Password> <PasswordDir> <Install dir> <Data dir> <Port> <Locale> <CheckACL>"
     exit 1
 }
 

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -19,8 +19,8 @@ if (-not $OSUsername -or -not $SuperUsername -or -not $Password -or -not $Passwo
     exit 1
 }
 
-# Create a temporary batch file
-$batchFileName = [System.IO.Path]::GetRandomFileName() -replace '\..*$', '.bat'
+# Create a temporary script file
+$scriptFileName = [System.IO.Path]::GetRandomFileName() -replace '\..*$', '.ps1'
 $outputFile = [System.IO.Path]::GetTempFileName()
 	
 # Function to log and terminate the script with an error message
@@ -44,17 +44,17 @@ function Warn {
 function DoCmd {
     param ([string]$Command)
 
-    $batchFile = Join-Path ([System.IO.Path]::GetTempPath()) $batchFileName
-    # Write command to the batch file
-    Set-Content -Path $batchFile -Value "@ECHO OFF"
-    Add-Content -Path $batchFile -Value "CHCP $([System.Text.Encoding]::Default.CodePage) > nul"
-    Add-Content -Path $batchFile -Value "$Command > `"$outputFile`" 2>&1"
-    Add-Content -Path $batchFile -Value "EXIT /B %ERRORLEVEL%"
+    $scriptFile = Join-Path ([System.IO.Path]::GetTempPath()) $scriptFileName
+	$fullCommand = "$Command | Out-File -FilePath `"$outputFile`" -Encoding UTF8"
 
-    Write-Host "Executing batch file '$batchFileName'..."
+    # Write command to the script file
+    $utf8BOM = New-Object System.Text.UTF8Encoding $true
+    [System.IO.File]::WriteAllText($scriptFile, $fullCommand, $utf8BOM
+
+    Write-Host "Executing script file '$scriptFileName'..."
     
-    # Execute the batch file
-    $process = Start-Process -FilePath "$env:WINDIR\System32\cmd.exe" -ArgumentList "/c `"$batchFile`"" -NoNewWindow -Wait -PassThru
+    # Execute the script file
+    $process = Start-Process -FilePath "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe" -ArgumentList "-ExecutionPolicy Bypass -File `"$scriptFile`"" -NoNewWindow -Wait -PassThru
     $exitCode = $process.ExitCode
 
     # Display output file content if exists
@@ -66,10 +66,10 @@ function DoCmd {
     }
 
     # Cleanup
-    if (Test-Path $batchFile) {
-        Remove-Item $batchFile -Force
+    if (Test-Path $scriptFile) {
+        Remove-Item $scriptFile -Force
     } else {
-        Write-Host "Batch file '$batchFileName' does not exist..."
+        Write-Host "Script file '$scriptFileName' does not exist..."
     }
 
     return $exitCode

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -45,7 +45,7 @@ function DoCmd {
     param ([string]$Command)
 
     $scriptFile = Join-Path ([System.IO.Path]::GetTempPath()) $scriptFileName
-	$fullCommand = "$Command | Out-File -FilePath `"$outputFile`" -Encoding UTF8"
+    $fullCommand = "$Command | Out-File -FilePath `"$outputFile`" -Encoding UTF8"
 
     # Write command to the script file
     $utf8BOM = New-Object System.Text.UTF8Encoding $true

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -49,7 +49,7 @@ function DoCmd {
 
     # Write command to the script file
     $utf8BOM = New-Object System.Text.UTF8Encoding $true
-    [System.IO.File]::WriteAllText($scriptFile, $fullCommand, $utf8BOM
+    [System.IO.File]::WriteAllText($scriptFile, $fullCommand, $utf8BOM)
 
     Write-Host "Executing script file '$scriptFileName'..."
     


### PR DESCRIPTION
Fix the installation failure that occurrs when the Windows username contains whitespaces or non-ASCII characters by:
1. Replacing the `${system_temp_directory}` variable in `pgserver.xml` with `${env(TEMP)}`.
The latter handles non-ASCII characters correctly, whereas the former corrupts them
when passing to powershell.
2. Replacing the temporary .bat file in `initcluster.ps1` with .ps1 script.
Powershell scripts offers flexibility in handling encoding issues and provide better control
over encoding management.
