### PR TITLE
set PG_SYSROOT instead of -isysroot

### DIFF
--- a/README
+++ b/README
@@ -104,7 +104,7 @@ build and install these packages into /usr/local/
 
 - Configure the source with a command such as:
 
-CFLAGS="-isysroot /Developer/SDKs/MacOSX10.5.sdk -mmacosx-version-min=10.5 -arch i386 -arch x86_64 -arch ppc" LDFLAGS="-arch i386 -arch ppc -arch x86_64" ./configure --prefix=/usr/local/ --disable-dependency-tracking
+CFLAGS="-mmacosx-version-min=10.5 -arch i386 -arch x86_64 -arch ppc" LDFLAGS="-arch i386 -arch ppc -arch x86_64" PG_SYSROOT="/Developer/SDKs/MacOSX10.5.sdk" ./configure --prefix=/usr/local/ --disable-dependency-tracking
 
 - Build and install:
 

--- a/settings.sh.in
+++ b/settings.sh.in
@@ -64,10 +64,11 @@ PG_DOCBOOK_OSX=/usr/local/Cellar/docbook-xsl/1.79.2_1/docbook-xsl
 MACOSX_MIN_VERSION=12
 ARCHFLAGS="-arch x86_64 -arch arm64"
 SDK_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
-PG_ARCH_OSX_CFLAGS="-isysroot $SDK_PATH -mmacosx-version-min=$MACOSX_MIN_VERSION $ARCHFLAGS"
-PG_ARCH_OSX_CPPFLAGS="-isysroot $SDK_PATH -mmacosx-version-min=$MACOSX_MIN_VERSION"
-PG_ARCH_OSX_CXXFLAGS="-isysroot $SDK_PATH -mmacosx-version-min=$MACOSX_MIN_VERSION $ARCHFLAGS"
-PG_ARCH_OSX_LDFLAGS="-isysroot $SDK_PATH -mmacosx-version-min=$MACOSX_MIN_VERSION $ARCHFLAGS"
+PG_SYSROOT="$SDK_PATH"
+PG_ARCH_OSX_CFLAGS="-mmacosx-version-min=$MACOSX_MIN_VERSION $ARCHFLAGS"
+PG_ARCH_OSX_CPPFLAGS="-mmacosx-version-min=$MACOSX_MIN_VERSION"
+PG_ARCH_OSX_CXXFLAGS="-mmacosx-version-min=$MACOSX_MIN_VERSION $ARCHFLAGS"
+PG_ARCH_OSX_LDFLAGS="-mmacosx-version-min=$MACOSX_MIN_VERSION $ARCHFLAGS"
 
 # The InstallBuilder main binary.
 PG_INSTALLBUILDER_BIN="/opt/installbuilder-23.11.0/bin/builder"


### PR DESCRIPTION
When -isysroot is added to CFLAGS, anyone who tries to compile extensions against the server headers will have to use the same SDK version and location as the server had, which may not be possible.

If the SDK path is placed into PG_SYSROOT instead, anyone who builds an extension against the server may point it to a setting that is more fitting to their environment.

This has been reported a few times by users of pgvector, with one of the latest being https://github.com/pgvector/pgvector/issues/592#issuecomment-2666735840