### PR TITLE
delete only mac format files in upgrade, not complete share directory

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -1313,7 +1313,7 @@ EOF
                 <deleteFile path="${installdir}${slash}include${slash}/unicode${slash}._*.h" />
                 <deleteFile path="${installdir}${slash}include${slash}/openssl${slash}._*.h" />
                 <deleteFile path="${installdir}${slash}include${slash}._*.h" />
-                <deleteFile path="${installdir}${slash}share" />
+                <deleteFile path="${installdir}${slash}share${slash}._*" />
             </actionList>
             <ruleList>
                 <compareText text="${platform_name}" logic="contains" value="windows" />


### PR DESCRIPTION
Delete only mac format files in upgrade mode, not complete share directory.
Some mac format files/folders were bundled by mistake in the installer,
which we deleted in upgrade mode. But as an attempt to achieve this,
complete share directory was getting deleted.
So, updating it to delete only required files inside share directory.

Jira issues: DBP-1274
edb-installer issues: #270 
--Manika Singhal, Tested by --Manika Singhal, Reviewed by --Sandeep Thakkar, Srinu Perabattula