### PR TITLE
This commit fixes multiple Windows installer issues. Listed in description.

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2046,7 +2046,7 @@
                 -->
                 <setInstallerVariable>
                     <name>localeCommand</name>
-                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 }  | Sort-Object EnglishName | ForEach-Object { $_.Name + '=' + $_.EnglishName } | Out-File -FilePath (Join-Path -Path "$env:TEMP\postgresql_installer_${random_number}" -ChildPath "locales.txt") -Encoding UTF8</value>
+                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 } | Sort-Object EnglishName | ForEach-Object { \"$($_.EnglishName)=$($_.EnglishName)\", \"$($_.Name)=$($_.Name)\" } | Out-File -FilePath (Join-Path -Path "$env:TEMP\postgresql_installer_${random_number}" -ChildPath "locales.txt") -Encoding UTF8</value>
                 </setInstallerVariable>
                 
                 <runProgram>
@@ -2971,7 +2971,7 @@
 
                         <runProgram>
                             <program>${env(WINDIR)}\System32\cmd.exe</program>
-                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" "${superpassword.password}" "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
+                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" '${superpassword.password}' "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
                             <progressText>${msg(progress.text.initialising.cluster)}</progressText>
                             <abortOnError>0</abortOnError>
                             <showMessageOnError>0</showMessageOnError>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2050,7 +2050,7 @@
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>
                 </runProgram>
-				<writeFile>
+                <writeFile>
                     <text>${program_stdout}</text>
                     <path>${env(TEMP)}\postgresql_installer_${random_number}\locales.txt</path>
                     <encoding>utf-8</encoding>
@@ -2071,11 +2071,11 @@
                     6. Append the output to the same temporary file where BCP names were saved.
                     7. This file is later used by the installer to populate locales drop down in installer.
                 -->
-				<setInstallerVariable>
+                <setInstallerVariable>
                     <name>localeLongNames</name>
                     <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 -and $_.EnglishName -match '^[\x00-\x7F]+$' } | Sort-Object EnglishName | ForEach-Object { $_.EnglishName + '=' + $_.EnglishName }</value>
                 </setInstallerVariable>
-				<runProgram>
+                <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
                     <programArguments>-ExecutionPolicy Bypass -Command "${localeLongNames}"</programArguments>
                     <wrapInScript>1</wrapInScript>
@@ -2083,7 +2083,7 @@
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>
                 </runProgram>
-				<addTextToFile>
+                <addTextToFile>
                     <text>${program_stdout}</text>
                     <file>${env(TEMP)}\postgresql_installer_${random_number}\locales.txt</file>
                     <encoding>utf-8</encoding>
@@ -3004,20 +3004,20 @@
                         </runProgram>
 
                         <setInstallerVariable name="escapedPassword" value="${superpassword}" />
-						<!--escaping " with \" before passing it to powershell script -->
-						<setInstallerVariableFromRegEx>
-							<name>escapedPassword</name>
-							<text>${escapedPassword}</text>
-							<pattern>"</pattern>
-							<substitution>\"</substitution>
-							<ruleList>
-								<compareText logic="equals" text="${platform_name}" value="windows"/>
-							</ruleList>
-						</setInstallerVariableFromRegEx>
+                        <!--escaping " with \" before passing it to powershell script -->
+                        <setInstallerVariableFromRegEx>
+                            <name>escapedPassword</name>
+                            <text>${escapedPassword}</text>
+                            <pattern>"</pattern>
+                            <substitution>\"</substitution>
+                            <ruleList>
+                                <compareText logic="equals" text="${platform_name}" value="windows"/>
+                            </ruleList>
+                        </setInstallerVariableFromRegEx>
 
                         <runProgram>
                             <program>${env(WINDIR)}\System32\cmd.exe</program>
-                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" '${escapedPassword.password}' "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
+                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" "${escapedPassword.password}" "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
                             <progressText>${msg(progress.text.initialising.cluster)}</progressText>
                             <abortOnError>0</abortOnError>
                             <showMessageOnError>0</showMessageOnError>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2100,7 +2100,7 @@
                 </writeFile>
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
-                    <programArguments>-ExecutionPolicy Bypass -File "$env:TEMP\postgresql_installer_${random_number}\getLocalesLongNames.ps1"</programArguments>
+                    <programArguments>-ExecutionPolicy Bypass -File "{env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1"</programArguments>
                     <wrapInScript>1</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2100,7 +2100,7 @@
                 </writeFile>
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
-                    <programArguments>-ExecutionPolicy Bypass -Command "${localeLongNames}"</programArguments>
+                    <programArguments>-ExecutionPolicy Bypass -File "${env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1"</programArguments>
                     <wrapInScript>1</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2969,9 +2969,21 @@
                             </ruleList>
                         </runProgram>
 
+                        <setInstallerVariable name="escapedPassword" value="${superpassword}" />
+						<!--escaping " with \" before passing it to powershell script -->
+						<setInstallerVariableFromRegEx>
+							<name>escapedPassword</name>
+							<text>${escapedPassword}</text>
+							<pattern>"</pattern>
+							<substitution>\"</substitution>
+							<ruleList>
+								<compareText logic="equals" text="${platform_name}" value="windows"/>
+							</ruleList>
+						</setInstallerVariableFromRegEx>
+
                         <runProgram>
                             <program>${env(WINDIR)}\System32\cmd.exe</program>
-                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" '${superpassword.password}' "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
+                            <programArguments>/c "${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" '${escapedPassword.password}' "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
                             <progressText>${msg(progress.text.initialising.cluster)}</progressText>
                             <abortOnError>0</abortOnError>
                             <showMessageOnError>0</showMessageOnError>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2100,7 +2100,7 @@
                 </writeFile>
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
-                    <programArguments>-ExecutionPolicy Bypass -File "${env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1"</programArguments>
+                    <programArguments>-ExecutionPolicy Bypass -File "$env:TEMP\postgresql_installer_${random_number}\getLocalesLongNames.ps1"</programArguments>
                     <wrapInScript>1</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2063,18 +2063,41 @@
                     and appends them in the same text file where BCP names were saved.  
 
                     Steps:
-                    1. Get all available cultures (languages/locales) using [System.Globalization.CultureInfo]::GetCultures.
-                    2. Filter out the "Invariant Culture" (LCID = 127), as it is not a valid locale.
-                    3. Filter only those locale names which contains non-ASCII characters ($_.EnglishName -match '^[\x00-\x7F]+$').
-                    4. Sort the locales by their English names for easier readability.
-                    5. Format each locale as "English_Name=English_Name" (e.g., "English (United States)=English (United States)"). So the locale passed to script will exactly be same what user selects.
-                    6. Append the output to the same temporary file where BCP names were saved.
-                    7. This file is later used by the installer to populate locales drop down in installer.
+                    1. Write a .ps1 to accomodate and split the complex powershell command.
+                    2. Get all available cultures (languages/locales) using [System.Globalization.CultureInfo]::GetCultures.
+                    3. Filter out the "Invariant Culture" (LCID = 127), as it is not a valid locale.
+                    4. Filter only those locale names which contains non-ASCII characters ($_.EnglishName -match '^[\x00-\x7F]+$').
+                    5. Sort the locales by their English names for easier readability.
+                    6. Format the locales English names in "Language, Region" format. This format is understable by initdb. (e.g., English (United States) will become English, United States)
+                    7. Format each locale as "Formatted_Name=Formatted_Name" (e.g., English, United States=English, United States). So the locale passed to script will exactly be same what user selects.
+                    8. Append the output to the same temporary file where BCP names were saved.
+                    9. This file is later used by the installer to populate locales drop down in installer.
                 -->
-                <setInstallerVariable>
-                    <name>localeLongNames</name>
-                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 -and $_.EnglishName -match '^[\x00-\x7F]+$' } | Sort-Object EnglishName | ForEach-Object { $_.EnglishName + '=' + $_.EnglishName }</value>
-                </setInstallerVariable>
+                <writeFile>
+					<path>${env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1</path>
+					<text>
+						<![CDATA[
+						$cultures = [System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures)
+						$filteredCultures = $cultures | Where-Object { $_.LCID -ne 127 -and $_.EnglishName -match '^[\x00-\x7F]+$' }
+						$sortedCultures = $filteredCultures | Sort-Object EnglishName
+						$localeLines = foreach ($culture in $sortedCultures) {
+						$name = $culture.EnglishName
+						if ($name -match '^([^,]+), ([^(]+) \(([^)]+)\)$') { 
+							$name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
+						} elseif ($name -match '^(.+?) \(([^,]+), (.+?)\)$') { 
+							$name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
+						} elseif ($name -match '^(.+?) \((.+)\)$') { 
+							$name = "$($matches[1]), $($matches[2])" 
+						}
+						"$name=$name"
+						}
+						$localeLines -join "`n"
+						]]>
+					</text>
+					<ruleList>
+                        <compareText logic="equals" text="${platform_name}" value="windows"/>
+                    </ruleList>
+				</writeFile>
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
                     <programArguments>-ExecutionPolicy Bypass -Command "${localeLongNames}"</programArguments>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2074,30 +2074,30 @@
                     9. This file is later used by the installer to populate locales drop down in installer.
                 -->
                 <writeFile>
-					<path>${env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1</path>
-					<text>
-						<![CDATA[
-						$cultures = [System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures)
-						$filteredCultures = $cultures | Where-Object { $_.LCID -ne 127 -and $_.EnglishName -match '^[\x00-\x7F]+$' }
-						$sortedCultures = $filteredCultures | Sort-Object EnglishName
-						$localeLines = foreach ($culture in $sortedCultures) {
-						$name = $culture.EnglishName
-						if ($name -match '^([^,]+), ([^(]+) \(([^)]+)\)$') { 
-							$name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
-						} elseif ($name -match '^(.+?) \(([^,]+), (.+?)\)$') { 
-							$name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
-						} elseif ($name -match '^(.+?) \((.+)\)$') { 
-							$name = "$($matches[1]), $($matches[2])" 
-						}
-						"$name=$name"
-						}
-						$localeLines -join "`n"
-						]]>
-					</text>
-					<ruleList>
-                        <compareText logic="equals" text="${platform_name}" value="windows"/>
-                    </ruleList>
-				</writeFile>
+                <path>${env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1</path>
+                <text>
+                    <![CDATA[
+                    $cultures = [System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures)
+                    $filteredCultures = $cultures | Where-Object { $_.LCID -ne 127 -and $_.EnglishName -match '^[\x00-\x7F]+$' }
+                    $sortedCultures = $filteredCultures | Sort-Object EnglishName
+                    $localeLines = foreach ($culture in $sortedCultures) {
+                    $name = $culture.EnglishName
+                    if ($name -match '^([^,]+), ([^(]+) \(([^)]+)\)$') { 
+                        $name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
+                    } elseif ($name -match '^(.+?) \(([^,]+), (.+?)\)$') { 
+                        $name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
+                    } elseif ($name -match '^(.+?) \((.+)\)$') { 
+                        $name = "$($matches[1]), $($matches[2])" 
+                    }
+                    "$name=$name"
+                    }
+                    $localeLines -join "`n"
+                    ]]>
+                </text>
+                <ruleList>
+                    <compareText logic="equals" text="${platform_name}" value="windows"/>
+                </ruleList>
+                </writeFile>
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
                     <programArguments>-ExecutionPolicy Bypass -Command "${localeLongNames}"</programArguments>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2072,6 +2072,7 @@
                     7. Format each locale as "Formatted_Name=Formatted_Name" (e.g., English, United States=English, United States). So the locale passed to script will exactly be same what user selects.
                     8. Append the output to the same temporary file where BCP names were saved.
                     9. This file is later used by the installer to populate locales drop down in installer.
+                    10. Use <![CDATA[ ... ]]> to wrap the PowerShell command below so that special XML characters like & and < do not cause parsing errors. This ensures the entire command is treated as raw text and not misinterpreted by the XML parser.
                 -->
                 <writeFile>
                 <path>${env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1</path>
@@ -2100,7 +2101,7 @@
                 </writeFile>
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
-                    <programArguments>-ExecutionPolicy Bypass -File "{env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1"</programArguments>
+                    <programArguments>-ExecutionPolicy Bypass -Command "&amp; { $scriptPath = Join-Path -Path "$env:TEMP\postgresql_installer_${random_number}" -ChildPath "getLocalesLongNames.ps1"; &amp; $scriptPath }"</programArguments>
                     <wrapInScript>1</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
@@ -2124,6 +2125,7 @@
                     </ruleList>
                 </readFile>
                 <deleteFile path="${env(TEMP)}\postgresql_installer_${random_number}\locales.txt"/>
+                <deleteFile path="{env(TEMP)}\postgresql_installer_${random_number}\getLocalesLongNames.ps1"/>
 
                 <throwError>
                     <text>${msg(script.command.line.error)}</text>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2028,35 +2028,69 @@
                     </ruleList>
                 </runProgram>
 
-                <!--This PowerShell command retrieves the list of all available locales on the system 
+                <!--This PowerShell command retrieves the list of BCP names of all available locales on the system 
                     and saves them in a text file for use during PostgreSQL installation.  
 
                     Steps:
                     1. Get all available cultures (languages/locales) using [System.Globalization.CultureInfo]::GetCultures.
                     2. Filter out the "Invariant Culture" (LCID = 127), as it is not a valid locale.
-                    3. Sort the locales by their English names for easier readability.
-                    4. Format each locale as "BCP-47_Code=English_Name" (e.g., "en-US=English (United States)").
-                    5. Save the output to a temporary file inside the system's TEMP directory.
-    
-                    Notes:
-                    - [System.IO.Path]::Combine ensures the path is correctly formatted, even if it contains spaces or non-ASCII characters.
-                    - The output file will be stored in:  
-                        C:\Users\<User>\AppData\Local\Temp\postgresql_installer_<random_number>\locales.txt
-                    - This file is later used by the installer to determine available system locales.
+                    3. Sort the locales by their BCP names for easier readability.
+                    4. Format each locale as "BCP-47_Name=BCP-47_Name" (e.g., "en-US=en-US"). So the locale passed to script will exactly be same what user selects.
+                    5. Write the output to a temporary file inside the system's TEMP directory.
                 -->
                 <setInstallerVariable>
-                    <name>localeCommand</name>
-                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 } | Sort-Object EnglishName | ForEach-Object { \"$($_.EnglishName)=$($_.EnglishName)\", \"$($_.Name)=$($_.Name)\" } | Out-File -FilePath (Join-Path -Path "$env:TEMP\postgresql_installer_${random_number}" -ChildPath "locales.txt") -Encoding UTF8</value>
+                    <name>localeBcpNames</name>
+                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 } | Sort-Object Name | ForEach-Object { $_.Name + '=' + $_.Name }</value>
                 </setInstallerVariable>
-                
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
-                    <programArguments>-ExecutionPolicy Bypass -Command "${localeCommand}"</programArguments>
+                    <programArguments>-ExecutionPolicy Bypass -Command "${localeBcpNames}"</programArguments>
                     <wrapInScript>1</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>
                 </runProgram>
+				<writeFile>
+                    <text>${program_stdout}</text>
+                    <path>${env(TEMP)}\postgresql_installer_${random_number}\locales.txt</path>
+                    <encoding>utf-8</encoding>
+                    <ruleList>
+                        <compareText logic="equals" text="${platform_name}" value="windows"/>
+                    </ruleList>
+                </writeFile>
+				
+                <!--This PowerShell command retrieves the list of English names of locales containing only ASCII characters
+                    and appends them in the same text file where BCP names were saved.  
+
+                    Steps:
+                    1. Get all available cultures (languages/locales) using [System.Globalization.CultureInfo]::GetCultures.
+                    2. Filter out the "Invariant Culture" (LCID = 127), as it is not a valid locale.
+                    3. Filter only those locale names which contains non-ASCII characters ($_.EnglishName -match '^[\x00-\x7F]+$').
+                    4. Sort the locales by their English names for easier readability.
+                    5. Format each locale as "English_Name=English_Name" (e.g., "English (United States)=English (United States)"). So the locale passed to script will exactly be same what user selects.
+                    6. Append the output to the same temporary file where BCP names were saved.
+                    7. This file is later used by the installer to populate locales drop down in installer.
+                -->
+				<setInstallerVariable>
+                    <name>localeLongNames</name>
+                    <value>[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 -and $_.EnglishName -match '^[\x00-\x7F]+$' } | Sort-Object EnglishName | ForEach-Object { $_.EnglishName + '=' + $_.EnglishName }</value>
+                </setInstallerVariable>
+				<runProgram>
+                    <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
+                    <programArguments>-ExecutionPolicy Bypass -Command "${localeLongNames}"</programArguments>
+                    <wrapInScript>1</wrapInScript>
+                    <ruleList>
+                        <compareText logic="equals" text="${platform_name}" value="windows"/>
+                    </ruleList>
+                </runProgram>
+				<addTextToFile>
+                    <text>${program_stdout}</text>
+                    <file>${env(TEMP)}\postgresql_installer_${random_number}\locales.txt</file>
+                    <encoding>utf-8</encoding>
+                    <ruleList>
+                        <compareText logic="equals" text="${platform_name}" value="windows"/>
+                    </ruleList>
+                </addTextToFile>
                 
                 <readFile>
                     <name>program_stdout</name>

--- a/server/resources/installation-notes.html
+++ b/server/resources/installation-notes.html
@@ -63,7 +63,7 @@ The debugger plugin is disabled by default for performance reasons. To enable it
 
 <ul>
   <li>Standard BCP-47 locale names (e.g., en-US, fr-FR). Recommeded, if the locale name contains non-ASCII characters (such as accented characters or regional scripts) </li>
-  <li>Long English locale names (e.g., English_United States, French_France) </li>
+  <li>Long English locale names containing only ASCII characters (e.g., English_United States, French_France). So, any non-ASCII character containing locale is not passed to the initdb. </li>
 </ul>
 
 <h3>Technical Support</h3>

--- a/server/resources/installation-notes.html
+++ b/server/resources/installation-notes.html
@@ -57,6 +57,15 @@ The debugger plugin is disabled by default for performance reasons. To enable it
 
 <p>PostgreSQL Server 17 is compiled with ICU 67.x. The server versions upto v12 used either ICU 53.x or  57.x. Hence, if you use pg_upgrade for a major version upgrade and have ICU collated indexes, then you need to reindex the indexes.</p>
 
+<h3>Important Note with regards to locale names</h3>
+
+<p>Starting from PostgreSQL versions 17.4, 16.8, 15.12, 14.17, and 13.20, the Windows installers support specifying locale names in two formats:</p>
+
+<ul>
+  <li>Standard BCP-47 locale names (e.g., en-US, fr-FR). Recommeded, if the locale name contains non-ASCII characters (such as accented characters or regional scripts) </li>
+  <li>Long English locale names (e.g., English_United States, French_France) </li>
+</ul>
+
 <h3>Technical Support</h3>
 
 <p>Issues using the installer can be reported to installer GitHub page at <a href="https://github.com/EnterpriseDB/edb-installers/issues">https://github.com/EnterpriseDB/edb-installers/issues</a></p>  

--- a/server/resources/installation-notes.html
+++ b/server/resources/installation-notes.html
@@ -59,7 +59,9 @@ The debugger plugin is disabled by default for performance reasons. To enable it
 
 <h3>Important Note with regards to locale names</h3>
 
-<p>Windows installers for PostgreSQL versions 17.4-1, 16.8-1, 15.12-1, 14.17-1, and 13.20-1, convert locale names to BCP-47 compulsorily before passing on to initdb. So, long name locales are not compatible in these installers.</p>
+<p>A change was made in the Windows installers for PostgreSQL versions 17.4-1, 16.8-1, 15.12-1, 14.17-1, and 13.20-1, and in the fresh installation the chosen locale name would be converted to BCP-47 name and passed to initdb.exe run as --locale. This change made the pg_upgrade from the PostgreSQL cluster having old locale names to these versions fail.</p>
+
+<p>The change was again made in -2 releases for the same set of postgresql installers. See below section for details.</p>
 
 <p>Starting from PostgreSQL versions 17.4-2, 16.8-2, 15.12-2, 14.17-2, and 13.20-2, the Windows installers support specifying locale names in two formats:</p>
 

--- a/server/resources/installation-notes.html
+++ b/server/resources/installation-notes.html
@@ -59,7 +59,7 @@ The debugger plugin is disabled by default for performance reasons. To enable it
 
 <h3>Important Note with regards to locale names</h3>
 
-<p>Windows installers for PostgreSQL versions 17.4-1, 16.8-1, 15.12-1, 14.17-1, and 13.20-1, locales are getting collected in long name format from the installer but they are compulsorily converted to BCP-47 codes before passing on to initdb. So, long name locales are not compatible in these installers.</p>
+<p>Windows installers for PostgreSQL versions 17.4-1, 16.8-1, 15.12-1, 14.17-1, and 13.20-1, convert locale names to BCP-47 compulsorily before passing on to initdb. So, long name locales are not compatible in these installers.</p>
 
 <p>Starting from PostgreSQL versions 17.4-2, 16.8-2, 15.12-2, 14.17-2, and 13.20-2, the Windows installers support specifying locale names in two formats:</p>
 

--- a/server/resources/installation-notes.html
+++ b/server/resources/installation-notes.html
@@ -59,7 +59,9 @@ The debugger plugin is disabled by default for performance reasons. To enable it
 
 <h3>Important Note with regards to locale names</h3>
 
-<p>Starting from PostgreSQL versions 17.4, 16.8, 15.12, 14.17, and 13.20, the Windows installers support specifying locale names in two formats:</p>
+<p>Windows installers for PostgreSQL versions 17.4-1, 16.8-1, 15.12-1, 14.17-1, and 13.20-1, locales are getting collected in long name format from the installer but they are compulsorily converted to BCP-47 codes before passing on to initdb. So, long name locales are not compatible in these installers.</p>
+
+<p>Starting from PostgreSQL versions 17.4-2, 16.8-2, 15.12-2, 14.17-2, and 13.20-2, the Windows installers support specifying locale names in two formats:</p>
 
 <ul>
   <li>Standard BCP-47 locale names (e.g., en-US, fr-FR). Recommeded, if the locale name contains non-ASCII characters (such as accented characters or regional scripts) </li>

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -226,18 +226,18 @@ if ($iRet -ne 0) {
     Write-Host "`nFailed to grant access to Administrators on $DataDir"
 }
 
-# fetch system's locale name in BCP-47 code dynamically
-if ($Locale -eq "DEFAULT") {
-	$Locale = (Get-WinSystemLocale).Name
-}
-
 # Create temporary password file
 $randomFileName = ($([guid]::NewGuid()).ToString("N").Substring(0,8)) + ".tmp"
 $passwordFile = Join-Path "$PasswordDir"  $randomFileName
 Set-Content -Path "$passwordFile" -Value $Password -Force
 
 # Set initdb command to be executed
-$initdbCmd = "& `"$InstallDir\\bin\\initdb.exe`" --pgdata=`"$DataDir`" --username=`"$SuperUsername`" --encoding=UTF8 --locale=`"$Locale`" --pwfile=`"$passwordFile`" --auth=scram-sha-256"
+if ($Locale -eq "DEFAULT") {
+    $initdbCmd = "& `"$InstallDir\\bin\\initdb.exe`" --pgdata=`"$DataDir`" --username=`"$SuperUsername`" --encoding=UTF8 --pwfile=`"$passwordFile`" --auth=scram-sha-256"
+}
+else {
+    $initdbCmd = "& `"$InstallDir\\bin\\initdb.exe`" --pgdata=`"$DataDir`" --username=`"$SuperUsername`" --encoding=UTF8 --locale=`"$Locale`" --pwfile=`"$passwordFile`" --auth=scram-sha-256"
+}
 
 # Run initdb
 Write-Host "`nInitializing PostgreSQL database cluster..."

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -16,7 +16,7 @@ param (
 
 # Validate input arguments
 if (-not $OSUsername -or -not $SuperUsername -or -not $LoggedInUser -or -not $Password -or -not $PasswordDir -or -not $InstallDir -or -not $DataDir -or -not $Port -or -not $Locale -or -not $CheckACL) {
-    Write-Host "Usage: initcluster.ps1 <OSUsername> <SuperUsername> <Password> <PasswordDir> <Install dir> <Data dir> <Port> <Locale> <CheckACL>"
+    Write-Host "Usage: initcluster.ps1 <OSUsername> <SuperUsername> <LoggedInUser> <Password> <PasswordDir> <Install dir> <Data dir> <Port> <Locale> <CheckACL>"
     exit 1
 }
 


### PR DESCRIPTION
1. populate installer's locale drop down with BCP names first followed by long names 
containing only ASCII characters.
**Reason:** providing compatibility with old style (long) locale names for the users who
want to still use old names for pg_upgrade. 
But removed all locales containing non-ASCII characters, so database initialisation will
not fail on any locale passed.

2. provide compatibility of passwords containing double quotes.
**Reason:** If password provided during installation contains double quotes, then 
initcluster.ps1 would fail. So, escaped double quotes by putting a \ before them and 
then passing it to the script.
**Note:** It will not affect the actual password provided by the user. User will be able 
to connect to server with the password they provided during installation.

3. update installation notes with the locales change info.
Reason: Installation notes did not contain any info about locales change introduced in 
the Feb'2025 release.

Jira issues: DBP-1351, DBP-1353, DBP-1352
edb-installers issue: #295, #293

--Manika Singhal, --Tested by -Manika Singhal, --Reviewed by -Sandeep Thakkar