### PR TITLE
update function to work properly when SID is not passed

### DIFF
--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -109,7 +109,7 @@ function AclCheck {
         return 0
     } else {
         # Decide whether to use SID or fallback to username
-		$userIdToGrant = if ($UserSid) { "*$UserSid" } else { "$UserName" }
+        $userIdToGrant = if ($UserSid) { "*$UserSid" } else { "$UserName" }
         Write-Host "Executing icacls to ensure the $UserName account can read the path $DirectoryPath"
 
         if ($Index -ne 0) {

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -108,15 +108,17 @@ function AclCheck {
         Write-Host "`nSkipping the ACL check on $DirectoryPath"
         return 0
     } else {
+        # Decide whether to use SID or fallback to username
+		$userIdToGrant = if ($UserSid) { "*$UserSid" } else { "$UserName" }
         Write-Host "Executing icacls to ensure the $UserName account can read the path $DirectoryPath"
 
         if ($Index -ne 0) {
             # For directories other than the root drive, grant permissions (NP)(RX)
-            $command = "$env:WINDIR\System32\icacls.exe `"$DirectoryPath`" /grant `"*$UserSid`:(NP)(RX)`""
+            $command = "$env:WINDIR\System32\icacls.exe `"$DirectoryPath`" /grant `"$userIdToGrant`:(NP)(RX)`""
         } else {
             # Drive letter must not be surronded by double-quotes and ends with slash (\)
             # "icacls" fails on the drives with (NP) flag
-            $command = "$env:WINDIR\System32\icacls.exe `"$DirectoryPath\\`" /grant `"*$UserSid`:(NP)(RX)`""
+            $command = "$env:WINDIR\System32\icacls.exe `"$DirectoryPath\\`" /grant `"$userIdToGrant`:(NP)(RX)`""
         }
         # Execute the command
         $iRet = DoCmd "$command"


### PR DESCRIPTION
Updated the function to suppress the warning messages script starts
to throw when username SID is not available to pass while calling the 
function at some places.

--Manika Singhal, Tested by- Manika Singhal, Reviewed by- Sandeep Thakkar