### PR TITLE
some more improvements in initcluster.ps1 to make it compatible for every environment

### DIFF
--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -47,7 +47,7 @@ function DoCmd {
 
     $scriptFile = Join-Path $env:TEMP $scriptFileName
     $outputFile = Join-Path $env:TEMP $outputFileName
-    $fullCommand = "$Command | Out-File -FilePath '$($outputFile.FullName)' -Encoding UTF8"
+    $fullCommand = "$Command | Out-File -FilePath '$outputFile' -Encoding UTF8"
 
     # Write command to the script file
     Set-Content -Path $scriptFile -Value $fullCommand -Encoding UTF8

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -22,7 +22,7 @@ if (-not $OSUsername -or -not $SuperUsername -or -not $LoggedInUser -or -not $Pa
 
 # Create a temporary script file
 $scriptFileName = ($([guid]::NewGuid()).ToString("N").Substring(0,8)) + ".ps1"
-$outputFileName = $([guid]::NewGuid()).ToString("N").Substring(0,8)) + ".tmp"
+$outputFileName = ($([guid]::NewGuid()).ToString("N").Substring(0,8)) + ".tmp"
 
 # Function to log and terminate the script with an error message
 function Die {

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -22,7 +22,7 @@ if (-not $OSUsername -or -not $SuperUsername -or -not $LoggedInUser -or -not $Pa
 
 # Create a temporary script file
 $scriptFileName = ($([guid]::NewGuid()).ToString("N").Substring(0,8)) + ".ps1"
-$outputFile = New-TemporaryFile
+$outputFileName = $([guid]::NewGuid()).ToString("N").Substring(0,8)) + ".tmp"
 
 # Function to log and terminate the script with an error message
 function Die {
@@ -46,6 +46,7 @@ function DoCmd {
     param ([string]$Command)
 
     $scriptFile = Join-Path $env:TEMP $scriptFileName
+    $outputFile = Join-Path $env:TEMP $outputFileName
     $fullCommand = "$Command | Out-File -FilePath '$($outputFile.FullName)' -Encoding UTF8"
 
     # Write command to the script file


### PR DESCRIPTION
`New-TemporaryFile` function is failing for some users.
So, replaced it with powershell in-built function and command.

edb-installers issue: #329 

--Manika Singhal, Tested by -- Manika Singhal, Reviewed by --Sandeep Thakkar