### PR TITLE
Improve DoCmd function in initcluster script

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2997,7 +2997,7 @@
                         <runProgram>
                             <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
                             <programArguments>-ExecutionPolicy Bypass -File "${installdir}\installer\server\initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" "${escapedPassword.password}" "${env(TEMP)}\postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
-                            <wrapInScript>1</wrapInScript>
+                            <wrapInScript>0</wrapInScript>
                             <progressText>${msg(progress.text.initialising.cluster)}</progressText>
                             <abortOnError>0</abortOnError>
                             <showMessageOnError>0</showMessageOnError>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2045,7 +2045,7 @@
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
                     <programArguments>-ExecutionPolicy Bypass -File "${env(TEMP)}\postgresql_installer_${random_number}\getlocales.ps1"</programArguments>
-                    <wrapInScript>1</wrapInScript>
+                    <wrapInScript>0</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2997,7 +2997,7 @@
                         <runProgram>
                             <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
                             <programArguments>-ExecutionPolicy Bypass -File "${installdir}\installer\server\initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" "${escapedPassword.password}" "${env(TEMP)}\postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
-                            <wrapInScript>0</wrapInScript>
+                            <wrapInScript>1</wrapInScript>
                             <progressText>${msg(progress.text.initialising.cluster)}</progressText>
                             <abortOnError>0</abortOnError>
                             <showMessageOnError>0</showMessageOnError>

--- a/server/scripts/windows/getlocales.ps1
+++ b/server/scripts/windows/getlocales.ps1
@@ -1,4 +1,4 @@
-# Powershell script to get system locales in their BCP-47 codes 
+﻿# Powershell script to get system locales in their BCP-47 codes
 # followed by the long names minus names with non-ASCII characters.
 
 

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -45,34 +45,34 @@ function Warn {
 function DoCmd {
     param ([string]$Command)
 
-    $scriptFile = Join-Path $env:TEMP $scriptFileName
-    $outputFile = Join-Path $env:TEMP $outputFileName
-    $fullCommand = "$Command | Out-File -FilePath '$outputFile' -Encoding UTF8"
+    Write-Host "Executing command: $Command"
 
-    # Write command to the script file
-    Set-Content -Path $scriptFile -Value $fullCommand -Encoding UTF8
+    # Use a temporary variable to hold the combined output (stdout and stderr)
+    # The '2>&1' is crucial. It merges the error stream (2) with the output stream (1).
+    # The '( )' ensures the entire command is treated as a single pipeline,
+    # allowing us to capture the output and check $LASTEXITCODE reliably.
+    $output = & "$env:WINDIR\System32\cmd.exe" /c $Command 2>&1
 
-    Write-Host "Executing script file '$scriptFileName'..."
+    # Check the exit code of the last executed native command
+    $exitCode = $LASTEXITCODE
 
-    # Execute the script file
-    $process = Start-Process -FilePath "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe" -ArgumentList "-ExecutionPolicy Bypass -File `"$scriptFile`"" -NoNewWindow -Wait -PassThru
-    $exitCode = $process.ExitCode
-
-    # Display output file content if exists
-    if (Test-Path $outputFile) {
-        Get-Content $outputFile | Write-Host
-        Remove-Item $outputFile -Force
+    # Display the captured output
+    if ($output) {
+        Write-Host "--- Command Output ---"
+        $output | Write-Host
+        Write-Host "----------------------"
     } else {
-        Write-Host "Output file does not exist..."
+        Write-Host "Command executed, but produced no output."
     }
 
-    # Cleanup
-    if (Test-Path $scriptFile) {
-        Remove-Item $scriptFile -Force
+    # If the command failed, print a clear error message
+    if ($exitCode -ne 0) {
+        Write-Host "`nERROR: Command failed with exit code $exitCode."
     } else {
-        Write-Host "Script file '$scriptFileName' does not exist..."
+        Write-Host "`nSUCCESS: Command completed successfully."
     }
 
+    # Return the exit code for the calling function to use
     return $exitCode
 }
 


### PR DESCRIPTION
No more temporary files: The variables $scriptFile, $outputFile,
and the associated Set-Content and Remove-Item calls are all gone.
The function no longer needs to write and execute an external script.
Direct Execution: The command is executed directly using cmd.exe /c.
to ensure the output streams and exit code are correctly captured.
The captured output is stored in a variable and then displayed to the
console, providing a clear view of what the command did. (Issue 347)

Also, disable wrapInScript for getlocales.ps1 as it was failing in
few conditions (Issue 343)

Issue #347 Issue #343