### PR TITLE
fix: Use call operator to run icacls.exe in the initcluster.ps1

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -1481,7 +1481,7 @@
         </unpackFile>
         <unpackFile>
             <component>server</component>
-            <destination>${system_temp_directory}/postgresql_installer_${random_number}/getlocales.ps1</destination>
+            <destination>${env(TEMP)}/postgresql_installer_${random_number}/getlocales.ps1</destination>
             <folder>programfileswindows</folder>
             <origin>installer/server/getlocales.ps1</origin>
             <ruleList>
@@ -2044,7 +2044,7 @@
 
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
-                    <programArguments>-ExecutionPolicy Bypass -File "${system_temp_directory}/postgresql_installer_${random_number}/getlocales.ps1"</programArguments>
+                    <programArguments>-ExecutionPolicy Bypass -File "${env(TEMP)}\postgresql_installer_${random_number}\getlocales.ps1"</programArguments>
                     <wrapInScript>1</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
@@ -2982,7 +2982,7 @@
 
                         <runProgram>
                             <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
-                            <programArguments>-ExecutionPolicy Bypass -File "${installdir}/installer/server/initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" "${escapedPassword.password}" "${env(TEMP)}/postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
+                            <programArguments>-ExecutionPolicy Bypass -File "${installdir}\installer\server\initcluster.ps1" "${serviceaccount}" "${superaccount}" "${whoami_sid}" "${escapedPassword.password}" "${env(TEMP)}\postgresql_installer_${random_number}" "${installdir}" "${datadir}" ${serverport} "${locale}" ${enable_aclcheck}</programArguments>
                             <wrapInScript>1</wrapInScript>
                             <progressText>${msg(progress.text.initialising.cluster)}</progressText>
                             <abortOnError>0</abortOnError>

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -82,14 +82,23 @@ function ClearAcl {
     param (
         [string]$DirectoryPath
     )
-    Write-Host "`nCalled ClearAcl ("$DirectoryPath")..."
-    $process = Start-Process -FilePath "$env:WINDIR\System32\icacls.exe" -ArgumentList `"$DirectoryPath`" -NoNewWindow -Wait -PassThru
-    Write-Host "`nRemoving inherited ACLs on ("$DirectoryPath")..."
-    $process = Start-Process -FilePath "$env:WINDIR\System32\icacls.exe" -ArgumentList `"$DirectoryPath`", /inheritance:r -NoNewWindow -Wait -PassThru
-    if ($process.ExitCode -ne 0) {
-        Write-Host "`nFailed to remove inherited ACLs on ("$DirectoryPath")"
+     Write-Host "`nCalled ClearAcl (`"$DirectoryPath`")..."
+    # Print current ACL
+    #Write-Host "`nCurrent ACL ("$DirectoryPath"):"
+    $currentAcl = & "$env:WINDIR\System32\icacls.exe" "`"$DirectoryPath`""
+    #$currentAcl | ForEach-Object { Write-Host $_ }
+
+    # Remove inherited ACLs
+    Write-Host "`nRemoving inherited ACLs on (`"$DirectoryPath`")..."
+    $output = & "$env:WINDIR\System32\icacls.exe" "`"$DirectoryPath`"" /inheritance:r
+    #$output | ForEach-Object { Write-Host $_ }
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "`nFailed to remove inherited ACLs on (`"$DirectoryPath`")"
+    } else {
+        Write-Host "`nSuccessfully removed inherited ACLs on (`"$DirectoryPath`")"
     }
-    return $process.ExitCode
+    return $LASTEXITCODE
 }
 
 # Function to check and set ACLs on the given directory


### PR DESCRIPTION
When Start-Process is used with -Wait and -PassThru, PowerShell sometimes
tries to access the process object after the process has already exited leading
to: Cannot process request because the process (PID) has exited

Hence, replace Start-Process with the & (call operator) while invoking icacls.exe
in the initcluster script.

Also replace / with \ for the paths on Windows

Issue https://github.com/EnterpriseDB/edb-installers/issues/332, Sandeep Thakkar, reviewed by Muralikrishna