### PR TITLE
Update initcluster.ps1 to convert "English, <Country> with English_<Country>"

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -2045,7 +2045,7 @@
                 <runProgram>
                     <program>${env(WINDIR)}\System32\WindowsPowerShell\v1.0\powershell.exe</program>
                     <programArguments>-ExecutionPolicy Bypass -File "${env(TEMP)}\postgresql_installer_${random_number}\getlocales.ps1"</programArguments>
-                    <wrapInScript>0</wrapInScript>
+                    <wrapInScript>1</wrapInScript>
                     <ruleList>
                         <compareText logic="equals" text="${platform_name}" value="windows"/>
                     </ruleList>

--- a/server/scripts/windows/getlocales.ps1
+++ b/server/scripts/windows/getlocales.ps1
@@ -1,31 +1,25 @@
 ﻿# Powershell script to get system locales in their BCP-47 codes
 # followed by the long names minus names with non-ASCII characters.
-# for English locales: "English, <Country>" → "English_<Country>"
+
 
 # fetching all system locales
 $cultures = [System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 }
 
-# formatting BCP names for locales in "key=value" style
+# formatting BCP names for locales in "key=value" style 
 $cultures | Sort-Object Name | ForEach-Object { $_.Name + '=' + $_.Name }
 
-# filter cultures containing only ASCII characters
+# filter cutlures containing only ASCII characters
 $filteredCultures = $cultures | Where-Object { $_.EnglishName -match '^[\x00-\x7F]+$' } | Sort-Object EnglishName
-
+ 
 # Formatting locales in a way that is recognizable by initdb
 foreach ($culture in $filteredCultures) {
     $name = $culture.EnglishName
-    if ($name -match '^([^,]+), ([^(]+) \(([^)]+)\)$') {
-        $name = "$($matches[1]) ($($matches[2])), $($matches[3])"
-    } elseif ($name -match '^(.+?) \(([^,]+), (.+?)\)$') {
-        $name = "$($matches[1]) ($($matches[2])), $($matches[3])"
-    } elseif ($name -match '^(.+?) \((.+)\)$') {
-        $name = "$($matches[1]), $($matches[2])"
+    if ($name -match '^([^,]+), ([^(]+) \(([^)]+)\)$') { 
+        $name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
+    } elseif ($name -match '^(.+?) \(([^,]+), (.+?)\)$') { 
+        $name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
+    } elseif ($name -match '^(.+?) \((.+)\)$') { 
+        $name = "$($matches[1]), $($matches[2])" 
     }
-
-    # Only change English locales: "English, <Country>" → "English_<Country>"
-    if ($name -match '^English, (.+)$') {
-        $name = "English_$($matches[1])"
-    }
-
-    "$name=$name"
+        "$name=$name"
 }

--- a/server/scripts/windows/getlocales.ps1
+++ b/server/scripts/windows/getlocales.ps1
@@ -1,25 +1,31 @@
 ﻿# Powershell script to get system locales in their BCP-47 codes
 # followed by the long names minus names with non-ASCII characters.
-
+# for English locales: "English, <Country>" → "English_<Country>"
 
 # fetching all system locales
 $cultures = [System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures) | Where-Object { $_.LCID -ne 127 }
 
-# formatting BCP names for locales in "key=value" style 
+# formatting BCP names for locales in "key=value" style
 $cultures | Sort-Object Name | ForEach-Object { $_.Name + '=' + $_.Name }
 
-# filter cutlures containing only ASCII characters
+# filter cultures containing only ASCII characters
 $filteredCultures = $cultures | Where-Object { $_.EnglishName -match '^[\x00-\x7F]+$' } | Sort-Object EnglishName
- 
+
 # Formatting locales in a way that is recognizable by initdb
 foreach ($culture in $filteredCultures) {
     $name = $culture.EnglishName
-    if ($name -match '^([^,]+), ([^(]+) \(([^)]+)\)$') { 
-        $name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
-    } elseif ($name -match '^(.+?) \(([^,]+), (.+?)\)$') { 
-        $name = "$($matches[1]) ($($matches[2])), $($matches[3])" 
-    } elseif ($name -match '^(.+?) \((.+)\)$') { 
-        $name = "$($matches[1]), $($matches[2])" 
+    if ($name -match '^([^,]+), ([^(]+) \(([^)]+)\)$') {
+        $name = "$($matches[1]) ($($matches[2])), $($matches[3])"
+    } elseif ($name -match '^(.+?) \(([^,]+), (.+?)\)$') {
+        $name = "$($matches[1]) ($($matches[2])), $($matches[3])"
+    } elseif ($name -match '^(.+?) \((.+)\)$') {
+        $name = "$($matches[1]), $($matches[2])"
     }
-        "$name=$name"
+
+    # Only change English locales: "English, <Country>" → "English_<Country>"
+    if ($name -match '^English, (.+)$') {
+        $name = "English_$($matches[1])"
+    }
+
+    "$name=$name"
 }

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -256,6 +256,10 @@ $initdbArgs = @(
 if ($Locale -ne "DEFAULT") {
     $initdbArgs += "--locale=`"$Locale`""
 }
+# Change English locales: "English, <Country>" → "English_<Country>"
+if ($Locale -match '^English, (.+)$') {
+    $Locale = "English_$($matches[1])"
+}
 
 # Print the full command
 Write-Host "`nExecuting: `"$InstallDir\bin\initdb.exe`" $initdbArgs `n"

--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -243,6 +243,11 @@ $randomFileName = ($([guid]::NewGuid()).ToString("N").Substring(0,8)) + ".tmp"
 $passwordFile = Join-Path "$PasswordDir"  $randomFileName
 Set-Content -Path "$passwordFile" -Value $Password -Force
 
+# Change English locales: "English, <Country>" → "English_<Country>"
+if ($Locale -match '^English, (.+)$') {
+    $Locale = "English_$($matches[1])"
+}
+
 # Run initdb
 Write-Host "`nInitializing PostgreSQL database cluster..."
 # Set initdb arguments
@@ -253,12 +258,9 @@ $initdbArgs = @(
 	"--pwfile=`"$passwordFile`"", 
 	"--auth=scram-sha-256"
 )
+
 if ($Locale -ne "DEFAULT") {
     $initdbArgs += "--locale=`"$Locale`""
-}
-# Change English locales: "English, <Country>" → "English_<Country>"
-if ($Locale -match '^English, (.+)$') {
-    $Locale = "English_$($matches[1])"
 }
 
 # Print the full command


### PR DESCRIPTION
The getlocales script returns the long names in the format "English, <Country>"
but it seems the Windows C library does not support it and requires it in 
English_<Country>.<CodePage> format. Hence, when any English long name 
locale is passed to initdb.exe in this format, it automatically sets the locale to 
"English_United States.1252"

This is reported by Ben Casp in pgsq-bugs and supported by Thomas Munro at: https://www.postgresql.org/messageid/CANFyU9642ZG81fmUPp7ceUNP%2Bb7ZnpWzAuzsTqoy5p1H%2BQEpag%40mail.gmail.com

As a quick work-around/fix, make changes in the initcluster script to convert 
the "English, <Country> with English_<Country>" before passing to initdb.exe

It was also found the installer is not populating the locales list when the getlocales
script is not wrapped i.e when wrapInScript is set to 0. Hence, set to 1 again and 
that reverts the fix done for #Issue 343. This will be addressed separately later

Sandeep Thakkar, Reviewed by Kritika Agarwal

DBP-1529