### PR TITLE
Add create_dmg.sh for macOS DMG creation

### DIFF
--- a/languagepack/build-osx.sh
+++ b/languagepack/build-osx.sh
@@ -104,7 +104,7 @@ _prep_languagepack_osx() {
 
     echo "Copy the scripts required to build VM"
     cd $WD/languagepack
-    scp $WD/versions.sh $WD/common.sh $WD/settings.sh $PG_SSH_OSX:$PG_PATH_OSX/ || _die "Failed to copy the scripts to be sourced to build VM"
+    scp $WD/versions.sh $WD/common.sh $WD/settings.sh $WD/resources/create_dmg.sh $PG_SSH_OSX:$PG_PATH_OSX/ || _die "Failed to copy the scripts to be sourced to build VM"
 
     echo "Extracting the archives"
     ssh $PG_SSH_OSX "cd $PG_PATH_OSX/languagepack/source; tar -jxvf python.tar.bz2" || _die "Failed to extract python archive on build VM"
@@ -394,14 +394,15 @@ _postprocess_languagepack_osx() {
     scp lp.img.tar.bz2 $PG_SSH_OSX:$PG_PATH_OSX/output ||  _die "Failed to copy lp.img.tar.bz2 to $PG_PATH_OSX/output."
     rm -rf lp.img* || _die "Failed to remove lp.img.tar.bz2 from output directory."
 
-    ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf lp.img.tar.bz2; hdiutil create -quiet -anyowners -srcfolder lp.img -format UDZO -volname 'EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK' -ov 'edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg'" || _die "Failed to create the disk image (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg)"
+    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf lp.img.tar.bz2; hdiutil create -quiet -anyowners -srcfolder lp.img -format UDZO -volname 'EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK' -ov 'edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg'" || _die "Failed to create the disk image (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg)"
+    ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf lp.img.tar.bz2; bash ../create_dmg.sh lp.img edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.app edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg '"EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK"'" || _die "create_dmg.sh script failed"
 
-    echo "Attach the  disk image, create zip and then detach the image"
-    ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; hdiutil detach '/Volumes/EDB_LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK* -force'; hdid edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg" || _die "Failed to open the disk image (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg in remote host)"
+    #echo "Attach the  disk image, create zip and then detach the image"
+    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; hdiutil detach '/Volumes/EDB_LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK* -force'; hdid edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg" || _die "Failed to open the disk image (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg in remote host)"
 
-    ssh $PG_SSH_OSX "cd '/Volumes/EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK'; zip -r $PG_PATH_OSX/output/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.zip edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.app" || _die "Failed to create the installer zip file (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.zip) in remote host."
+    #ssh $PG_SSH_OSX "cd '/Volumes/EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK'; zip -r $PG_PATH_OSX/output/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.zip edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.app" || _die "Failed to create the installer zip file (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.zip) in remote host."
 
-    ssh $PG_SSH_OSX "cd $PG_PATH_OSX; sleep 2; echo 'Detaching /Volumes/edb-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK...' ; hdiutil detach '/Volumes/edb-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK'" || _die "Failed to detach the /Volumes/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK in remote host."
+    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX; sleep 2; echo 'Detaching /Volumes/edb-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK...' ; hdiutil detach '/Volumes/edb-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK'" || _die "Failed to detach the /Volumes/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK in remote host."
 
     scp $PG_SSH_OSX:$PG_PATH_OSX/output/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.* $WD/output || _die "Failed to copy installers to $WD/output."
 

--- a/languagepack/build-osx.sh
+++ b/languagepack/build-osx.sh
@@ -394,15 +394,7 @@ _postprocess_languagepack_osx() {
     scp lp.img.tar.bz2 $PG_SSH_OSX:$PG_PATH_OSX/output ||  _die "Failed to copy lp.img.tar.bz2 to $PG_PATH_OSX/output."
     rm -rf lp.img* || _die "Failed to remove lp.img.tar.bz2 from output directory."
 
-    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf lp.img.tar.bz2; hdiutil create -quiet -anyowners -srcfolder lp.img -format UDZO -volname 'EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK' -ov 'edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg'" || _die "Failed to create the disk image (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg)"
     ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf lp.img.tar.bz2; bash ../create_dmg.sh lp.img edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.app edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg '"EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK"'" || _die "create_dmg.sh script failed"
-
-    #echo "Attach the  disk image, create zip and then detach the image"
-    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; hdiutil detach '/Volumes/EDB_LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK* -force'; hdid edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg" || _die "Failed to open the disk image (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.dmg in remote host)"
-
-    #ssh $PG_SSH_OSX "cd '/Volumes/EDB-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK'; zip -r $PG_PATH_OSX/output/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.zip edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.app" || _die "Failed to create the installer zip file (edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.zip) in remote host."
-
-    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX; sleep 2; echo 'Detaching /Volumes/edb-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK...' ; hdiutil detach '/Volumes/edb-LanguagePack $PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK'" || _die "Failed to detach the /Volumes/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK in remote host."
 
     scp $PG_SSH_OSX:$PG_PATH_OSX/output/edb-languagepack-$PG_VERSION_LANGUAGEPACK-$PG_BUILDNUM_LANGUAGEPACK-${BUILD_FAILED}osx.* $WD/output || _die "Failed to copy installers to $WD/output."
 

--- a/resources/create_dmg.sh
+++ b/resources/create_dmg.sh
@@ -47,12 +47,6 @@ echo "Calculating size of app bundle..."
 BUNDLE_SIZE=$(du -sk "${SOURCE_FOLDER}/${APP_BUNDLE}" | awk '{print $1}')
 DMG_SIZE_MB=$((BUNDLE_SIZE / 1024 + 50)) # Add a 50MB buffer
 
-# Check if the temporary DMG is present
-if [ -f "${TEMP_DMG_NAME}" ]; then
-    rm -f ${TEMP_DMG_NAME}
-    echo "Deleted temp.dmg"
-fi
-
 echo "Creating a temporary blank disk image of size ${DMG_SIZE_MB}MB..."
 for i in $(seq 1 ${MAX_CREATE_RETRIES}); do
     if hdiutil create -size "${DMG_SIZE_MB}m" \

--- a/resources/create_dmg.sh
+++ b/resources/create_dmg.sh
@@ -47,6 +47,12 @@ echo "Calculating size of app bundle..."
 BUNDLE_SIZE=$(du -sk "${SOURCE_FOLDER}/${APP_BUNDLE}" | awk '{print $1}')
 DMG_SIZE_MB=$((BUNDLE_SIZE / 1024 + 50)) # Add a 50MB buffer
 
+# Check if the temporary DMG is present
+if [ -f "${TEMP_DMG_NAME}" ]; then
+    rm -f ${TEMP_DMG_NAME}
+    echo "Deleted temp.dmg"
+fi
+
 echo "Creating a temporary blank disk image of size ${DMG_SIZE_MB}MB..."
 for i in $(seq 1 ${MAX_CREATE_RETRIES}); do
     if hdiutil create -size "${DMG_SIZE_MB}m" \

--- a/resources/create_dmg.sh
+++ b/resources/create_dmg.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+  
+# A simple shell script to create a compressed, read-only DMG from a folder.
+
+# --- Usage and Input Validation ---
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 <source_folder> <app_bundle_name> <output_dmg_name> <volume_name>"
+    echo "Example: $0 ./build/MyApp ./MyApp.app MyApp.dmg 'My Application'"
+    exit 1
+fi
+
+# --- Configuration ---
+# The script now takes the following inputs from the command line:
+SOURCE_FOLDER="${1}"
+APP_BUNDLE="${2}"
+DMG_NAME="${3}"
+VOLUME_NAME="${4}"
+
+# The name of the temporary read/write DMG created during the process.
+TEMP_DMG_NAME="temp.dmg"
+MAX_CREATE_RETRIES=10
+RETRY_DELAY=2
+
+# --- Main Script ---
+set -e
+
+# Check if the source folder exists
+if [ ! -d "${SOURCE_FOLDER}" ]; then
+    echo "Error: Source folder '${SOURCE_FOLDER}' not found."
+    exit 1
+fi
+
+# Check if the app bundle exists within the source folder
+if [ ! -d "${SOURCE_FOLDER}/${APP_BUNDLE}" ]; then
+    echo "Error: App bundle '${APP_BUNDLE}' not found inside '${SOURCE_FOLDER}'."
+    exit 1
+fi
+
+# Step 1: Create a ZIP archive of the app bundle.
+echo "Creating a ZIP archive of the app bundle..."
+zip -r "${APP_BUNDLE}.zip" "${SOURCE_FOLDER}/${APP_BUNDLE}"
+
+# Step 2: Determine the size of the app bundle and create a blank, writable temporary image.
+# This avoids "Resource busy" errors by not reading the source directory during creation.
+echo "Calculating size of app bundle..."
+# Get the size in megabytes and add a buffer
+BUNDLE_SIZE=$(du -sk "${SOURCE_FOLDER}/${APP_BUNDLE}" | awk '{print $1}')
+DMG_SIZE_MB=$((BUNDLE_SIZE / 1024 + 50)) # Add a 50MB buffer
+
+echo "Creating a temporary blank disk image of size ${DMG_SIZE_MB}MB..."
+for i in $(seq 1 ${MAX_CREATE_RETRIES}); do
+    if hdiutil create -size "${DMG_SIZE_MB}m" \
+                      -volname "${VOLUME_NAME}" \
+                      -anyowners \
+                      -fs HFS+J \
+                      -o "${TEMP_DMG_NAME}"; then
+        echo "Temporary DMG created successfully."
+        break
+    else
+        echo "Attempt $i of ${MAX_CREATE_RETRIES} failed: hdiutil create failed. Retrying in ${RETRY_DELAY} seconds..."
+        sleep "${RETRY_DELAY}"
+    fi
+done
+
+# Check if the temporary DMG was created successfully after all retries
+if [ ! -f "${TEMP_DMG_NAME}" ]; then
+    echo "Error: Failed to create temporary DMG file after ${MAX_CREATE_RETRIES} attempts. Manual intervention may be required."
+    exit 1
+fi
+
+# Step 3: Attach the newly created temporary disk image.
+echo "Attaching the temporary disk image..."
+hdiutil attach "${TEMP_DMG_NAME}" -nobrowse -mountpoint "/Volumes/${VOLUME_NAME}"
+
+# Check if the volume was mounted successfully
+if [ ! -d "/Volumes/${VOLUME_NAME}" ]; then
+    echo "Error: Failed to mount the temporary DMG."
+    hdiutil detach "/Volumes/${VOLUME_NAME}" 2>/dev/null
+    rm -f "${TEMP_DMG_NAME}"
+    exit 1
+fi
+
+# Step 4: Copy the app bundle into the mounted image.
+echo "Copying app bundle into the mounted image..."
+cp -r "${SOURCE_FOLDER}/${APP_BUNDLE}" "/Volumes/${VOLUME_NAME}/"
+
+# Step 5: Detach the temporary disk image with a force option.
+echo "Detaching the temporary disk image..."
+hdiutil detach "/Volumes/${VOLUME_NAME}" || {
+    echo "Failed to detach. Attempting a forced detach..."
+    hdiutil detach -force "/Volumes/${VOLUME_NAME}" || {
+        echo "Error: Failed to force detach the temporary DMG. Manual intervention may be required."
+        rm -f "${TEMP_DMG_NAME}"
+        exit 1
+    }
+}
+
+# Step 6: Convert the temporary read/write DMG to a compressed, read-only DMG.
+# This is the final, distributable file.
+# The `-quiet` flag suppresses the progress bar.
+echo "Converting to a compressed, read-only disk image..."
+hdiutil convert "${TEMP_DMG_NAME}" \
+                -format UDZO \
+                -o "${DMG_NAME}" \
+                -quiet
+
+# Step 7: Clean up the temporary file.
+echo "Cleaning up temporary files..."
+rm -f "${TEMP_DMG_NAME}"
+
+echo "Done! The final DMG is '${DMG_NAME}'."

--- a/server/build-osx.sh
+++ b/server/build-osx.sh
@@ -595,15 +595,7 @@ _postprocess_server_osx() {
     scp server.img.tar.bz2 $PG_SSH_OSX:$PG_PATH_OSX/output || _die "Failed to copy server.img.tar.bz2 to $PG_PATH_OSX/output"
     rm -rf server.img* || _die "Failed to remove server.img from output directory."
 
-    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf server.img.tar.bz2; touch server.img/.Trash; hdiutil create -quiet -anyowners -srcfolder server.img -format UDZO -volname 'PostgreSQL $PG_PACKAGE_VERSION' -ov 'postgresql-$PG_PACKAGE_VERSION-osx.dmg'" || _die "Failed to create the disk image (postgresql-$PG_PACKAGE_VERSION-osx.dmg)"
     ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf server.img.tar.bz2; bash ../create_dmg.sh server.img postgresql-$PG_PACKAGE_VERSION-${BUILD_FAILED}osx.app postgresql-$PG_PACKAGE_VERSION-${BUILD_FAILED}osx.dmg '"PostgreSQL $PG_PACKAGE_VERSION"'" || _die "create_dmg.sh script failed"
-
-    #echo "Attach the  disk image, create zip and then detach the image"
-    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; hdiutil detach '/Volumes/PostgreSQL $PG_PACKAGE_VERSION* -force'; hdid postgresql-$PG_PACKAGE_VERSION-osx.dmg" || _die "Failed to open the disk image (postgresql-$PG_PACKAGE_VERSION-osx.dmg in remote host.)"
-
-    #ssh $PG_SSH_OSX "cd '/Volumes/PostgreSQL $PG_PACKAGE_VERSION'; zip -r $PG_PATH_OSX/output/postgresql-$PG_PACKAGE_VERSION-osx.zip postgresql-$PG_PACKAGE_VERSION-osx.app" || _die "Failed to create the installer zip file (postgresql-$PG_PACKAGE_VERSION-osx.zip) in remote host."
-
-    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX; sleep 2; echo 'Detaching /Volumes/PostgreSQL $PG_PACKAGE_VERSION...' ; hdiutil detach '/Volumes/PostgreSQL $PG_PACKAGE_VERSION'" || _die "Failed to detach the /Volumes/PostgreSQL $PG_PACKAGE_VERSION in remote host."
 
     scp $PG_SSH_OSX:$PG_PATH_OSX/output/postgresql-$PG_PACKAGE_VERSION-osx.* $WD/output || _die "Failed to copy installers to $WD/output."
 

--- a/server/build-osx.sh
+++ b/server/build-osx.sh
@@ -122,7 +122,7 @@ _prep_server_osx() {
     cd $WD/server
     tar -jcvf scripts.tar.bz2 scripts/osx resources/complete-bundle.sh resources/framework-config.sh resources/Info.plist-template_Qt5
     scp $WD/server/scripts.tar.bz2 $PG_SSH_OSX:$PG_PATH_OSX/server || _die "Failed to copy the scripts to build VM"
-    scp $WD/versions.sh $WD/common.sh $WD/settings.sh $WD/resources/create_debug_symbols.sh $PG_SSH_OSX:$PG_PATH_OSX/ || _die "Failed to copy the scripts to be sourced to build VM"
+    scp $WD/versions.sh $WD/common.sh $WD/settings.sh $WD/resources/create_debug_symbols.sh $WD/resources/create_dmg.sh $PG_SSH_OSX:$PG_PATH_OSX/ || _die "Failed to copy the scripts to be sourced to build VM"
     rm -f scripts.tar.bz2 || _die "Couldn't remove the scipts archive (source/scripts.tar.bz2)"    
 
     echo "Extracting the archives"
@@ -595,14 +595,15 @@ _postprocess_server_osx() {
     scp server.img.tar.bz2 $PG_SSH_OSX:$PG_PATH_OSX/output || _die "Failed to copy server.img.tar.bz2 to $PG_PATH_OSX/output"
     rm -rf server.img* || _die "Failed to remove server.img from output directory."
 
-    ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf server.img.tar.bz2; touch server.img/.Trash; hdiutil create -quiet -anyowners -srcfolder server.img -format UDZO -volname 'PostgreSQL $PG_PACKAGE_VERSION' -ov 'postgresql-$PG_PACKAGE_VERSION-osx.dmg'" || _die "Failed to create the disk image (postgresql-$PG_PACKAGE_VERSION-osx.dmg)"
+    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf server.img.tar.bz2; touch server.img/.Trash; hdiutil create -quiet -anyowners -srcfolder server.img -format UDZO -volname 'PostgreSQL $PG_PACKAGE_VERSION' -ov 'postgresql-$PG_PACKAGE_VERSION-osx.dmg'" || _die "Failed to create the disk image (postgresql-$PG_PACKAGE_VERSION-osx.dmg)"
+    ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; source $PG_PATH_OSX/versions.sh; tar -jxvf server.img.tar.bz2; bash ../create_dmg.sh server.img postgresql-$PG_PACKAGE_VERSION-${BUILD_FAILED}osx.app postgresql-$PG_PACKAGE_VERSION-${BUILD_FAILED}osx.dmg '"PostgreSQL $PG_PACKAGE_VERSION"'" || _die "create_dmg.sh script failed"
 
-    echo "Attach the  disk image, create zip and then detach the image"
-    ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; hdiutil detach '/Volumes/PostgreSQL $PG_PACKAGE_VERSION* -force'; hdid postgresql-$PG_PACKAGE_VERSION-osx.dmg" || _die "Failed to open the disk image (postgresql-$PG_PACKAGE_VERSION-osx.dmg in remote host.)"
+    #echo "Attach the  disk image, create zip and then detach the image"
+    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX/output; hdiutil detach '/Volumes/PostgreSQL $PG_PACKAGE_VERSION* -force'; hdid postgresql-$PG_PACKAGE_VERSION-osx.dmg" || _die "Failed to open the disk image (postgresql-$PG_PACKAGE_VERSION-osx.dmg in remote host.)"
 
-    ssh $PG_SSH_OSX "cd '/Volumes/PostgreSQL $PG_PACKAGE_VERSION'; zip -r $PG_PATH_OSX/output/postgresql-$PG_PACKAGE_VERSION-osx.zip postgresql-$PG_PACKAGE_VERSION-osx.app" || _die "Failed to create the installer zip file (postgresql-$PG_PACKAGE_VERSION-osx.zip) in remote host."
+    #ssh $PG_SSH_OSX "cd '/Volumes/PostgreSQL $PG_PACKAGE_VERSION'; zip -r $PG_PATH_OSX/output/postgresql-$PG_PACKAGE_VERSION-osx.zip postgresql-$PG_PACKAGE_VERSION-osx.app" || _die "Failed to create the installer zip file (postgresql-$PG_PACKAGE_VERSION-osx.zip) in remote host."
 
-    ssh $PG_SSH_OSX "cd $PG_PATH_OSX; sleep 2; echo 'Detaching /Volumes/PostgreSQL $PG_PACKAGE_VERSION...' ; hdiutil detach '/Volumes/PostgreSQL $PG_PACKAGE_VERSION'" || _die "Failed to detach the /Volumes/PostgreSQL $PG_PACKAGE_VERSION in remote host."
+    #ssh $PG_SSH_OSX "cd $PG_PATH_OSX; sleep 2; echo 'Detaching /Volumes/PostgreSQL $PG_PACKAGE_VERSION...' ; hdiutil detach '/Volumes/PostgreSQL $PG_PACKAGE_VERSION'" || _die "Failed to detach the /Volumes/PostgreSQL $PG_PACKAGE_VERSION in remote host."
 
     scp $PG_SSH_OSX:$PG_PATH_OSX/output/postgresql-$PG_PACKAGE_VERSION-osx.* $WD/output || _die "Failed to copy installers to $WD/output."
 

--- a/settings.sh.in
+++ b/settings.sh.in
@@ -70,6 +70,6 @@ PG_ARCH_OSX_CXXFLAGS="-isysroot $SDK_PATH -mmacosx-version-min=$MACOSX_MIN_VERSI
 PG_ARCH_OSX_LDFLAGS="-isysroot $SDK_PATH -mmacosx-version-min=$MACOSX_MIN_VERSION $ARCHFLAGS"
 
 # The InstallBuilder main binary.
-PG_INSTALLBUILDER_BIN="/opt/installbuilder-23.11.0/bin/builder"
+PG_INSTALLBUILDER_BIN="/opt/installbuilder-25.6.0/bin/builder"
 KEYCHAIN_PASSWD="XXXXXX"
 DEVELOPER_ID="Developer ID Application: EnterpriseDB Corporation"

--- a/versions.sh
+++ b/versions.sh
@@ -3,7 +3,7 @@
 # Source tarball versions
 
 PG_TARBALL_POSTGRESQL=18rc1
-PG_TARBALL_PGADMIN=9.8
+PG_TARBALL_PGADMIN=9.7
 PG_LP_VERSION=6.0rc1
 
 # Build nums

--- a/versions.sh
+++ b/versions.sh
@@ -3,7 +3,7 @@
 # Source tarball versions
 
 PG_TARBALL_POSTGRESQL=18rc1
-PG_TARBALL_PGADMIN=9.7
+PG_TARBALL_PGADMIN=9.8
 PG_LP_VERSION=6.0rc1
 
 # Build nums


### PR DESCRIPTION
This commit separates the DMG creation logic into its own script, create_dmg.sh. This improves maintainability and reusability by isolating the specific steps required for building macOS disk images.