### PR TITLE
Fix(vcredist): Correctly detect and log VCRedist versions before down…

### DIFF
--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -1754,6 +1754,8 @@
                                 <key>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64</key>
                                 <variable>vcredist_ver</variable>
                         </registryGet>
+						<logMessage text="Installed VC++ runtimes version: ${vcredist_ver}" />
+			            <logMessage text="Bundled VC++ runtime version: @@VCREDIST_BUNDLED_VER@@" />
                         <setInstallerVariable name="install_runtimes" value="0">
                                 <ruleList>
                                     <stringTest>


### PR DESCRIPTION
…load.

The installation script was skipping VCRedist download based on an incomplete version check. This commit modifies the logic to explicitly compare and print the bundled VCRedist version against the version currently installed on the user's machine, ensuring proper dependency management and improved diagnostic output.

Issue #407, Sandeep Thakkar, Reviewed by: Kritika Agarwal & Srinu Perrabattula