### PR TITLE
DBP-1806--extract-only Install Create Uninstall Registry Key

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -975,6 +975,7 @@ EOF
             <value>PG_PACKAGE_MINOR_VERSION</value>
             <ruleList>
 		<compareText logic="equals" text="${platform_name}" value="windows"/>
+		<isFalse value="${extract_mode}"/>
             </ruleList>
         </registrySet>
         <registrySet>
@@ -983,6 +984,7 @@ EOF
             <value>PG_PACKAGE_VERSION</value>
 	    <ruleList>
 		<compareText logic="equals" text="${platform_name}" value="windows"/>
+		<isFalse value="${extract_mode}"/>
             </ruleList>
         </registrySet>
     </postUninstallerCreationActionList>


### PR DESCRIPTION
Updated installer.xml.in and fixed a bug where the installer would create an uninstallation registry entry even when using the --extract-only command-line switch.