### PR TITLE
DBP-1832-PostgreSQL Windows Installation Failed: Database cluster initialization failed during post-install step v17

### DIFF
--- a/server/scripts/windows/initcluster.ps1
+++ b/server/scripts/windows/initcluster.ps1
@@ -248,6 +248,9 @@ if ($Locale -match '^English, (.+)$') {
     $Locale = "English_$($matches[1])"
 }
 
+# Prepend the current bin directory to the PATH so initdb finds the correct postgres.exe
+$env:PATH = "$InstallDir\bin;" + $env:PATH
+
 # Run initdb
 Write-Host "`nInitializing PostgreSQL database cluster..."
 # Set initdb arguments
@@ -339,3 +342,4 @@ if ($iRet -ne 0) {
 }
 
 Write-Host "`ninitcluster.ps1 ran to completion."
+


### PR DESCRIPTION
During the execution of the initcluster.ps1 script, the PostgreSQL initialization utility (initdb.exe) was failing with an error stating that the postgres program was found but was "not the same version as initdb."

This happens because initdb.exe is a coordinator. To set up the database, it must first launch the core engine (postgres.exe) to verify compatibility. On Windows, if the system has older versions of PostgreSQL files hidden in folders like C:\Windows\System32 or other legacy installation paths, initdb.exe may accidentally find and try to use those old files instead of the new latest version files.

To resolve this, modified the script to create a controlled execution environment.

By adding the local $InstallDir\bin folder to the start of the PATH variable, It change the search priority. By placing our folder at the very beginning, ensure that initdb.exe finds the matching latest version postgres.exe.

Issues #407, #531

----------------
Mayank Jaiswal, Reviewed by Sandeep Thakkar, Srinu Perabattula