### PR TITLE
Update meson.bat to run ECPG regression tests

### DIFF
--- a/server/scripts/windows/meson.bat
+++ b/server/scripts/windows/meson.bat
@@ -20,6 +20,7 @@ cd %BASE_PATH%\%SOURCE_DIR%\meson-build
 ECHO meson build dir content
 dir
 ninja --verbose
+ninja testprep
 
 ninja install
 dir %BASE_PATH%\%SOURCE_DIR%\meson-install


### PR DESCRIPTION
Implemented Meson test runs for PostgreSQL 17 

ECPG regression tests were failing with "Could not open file" errors for missing files like dec_test.c.  Added "ninja testprep" to the meson.bat build script to explicitly trigger the generation of required .c files before running the ECPG regression tests through the meson test command.

Mayank Jaiswal,

DBP-1801