### PR TITLE
Remove that legacy yarn setting

### DIFF
--- a/server/build-pgadmin.sh.in
+++ b/server/build-pgadmin.sh.in
@@ -31,6 +31,9 @@ _cleanup() {
 	echo "Cleaning up the old environment and app bundle..."
 	rm -rf "${BUILD_ROOT}"
 	rm -rf "${TEMP_DIR}"
+	# Remove any stray yarn config from parent directories that may interfere with build
+    SCRIPT_DIR=$(dirname "${SOURCE_DIR}")
+    rm -rf "${SCRIPT_DIR}/.yarn" "${SCRIPT_DIR}/.yarnrc.yml" 2>/dev/null || true
 }
 
 _create_python_env() {

--- a/server/build-pgadmin.sh.in
+++ b/server/build-pgadmin.sh.in
@@ -289,6 +289,9 @@ _complete_bundle() {
                 if (( $(echo "${APP_LONG_VERSION} <= 9.5" | bc -l) )); then
                  npm pkg set "scripts.git:hash=exit 0"
                 fi
+				# Remove legacy yarn config setting not supported in newer Yarn versions
+                sed -i '' '/^approvedGitRepositories:/,/^[^ ]/{ /^approvedGitRepositories:/d; /^  - /d; }' .yarnrc.yml
+				
                 yarn set version berry
                 yarn set version 4
 		yarn install

--- a/server/build-pgadmin.sh.in
+++ b/server/build-pgadmin.sh.in
@@ -292,11 +292,8 @@ _complete_bundle() {
                 if (( $(echo "${APP_LONG_VERSION} <= 9.5" | bc -l) )); then
                  npm pkg set "scripts.git:hash=exit 0"
                 fi
-				# Remove legacy yarn config setting not supported in newer Yarn versions
-                sed -i '' '/^approvedGitRepositories:/,/^[^ ]/{ /^approvedGitRepositories:/d; /^  - /d; }' .yarnrc.yml
-				
-                yarn set version berry
-                yarn set version 4
+        yarn set version berry
+        yarn set version 4
 		yarn install
 		yarn run bundle
 


### PR DESCRIPTION
The pgAdmin 9.15 source has a .yarnrc.yml file with a legacy configuration option approvedGitRepositories that's not supported in newer Yarn versions.