### PR TITLE
Off-cycle release for v16 to update the OpenSSL version.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,10 @@
+# PostgreSQL installer release 16.14-2 (2026-06-11)
+## Changes 🛠️
+- **Dependencies (macOS & Windows)**
+    - Update `openssl` version to `3.0.21`
+
+-------------------------------------------------------------------------------------------------------------------------------
+
 # PostgreSQL installer release 16.14-1 (2026-05-14)
 ## Changes 🛠️
 - Update `pgAdmin4` to version `9.15`

--- a/server/packages-win64.txt
+++ b/server/packages-win64.txt
@@ -9,4 +9,4 @@ icu-67-1-windows-x64.tar.bz2
 uuid-1.6.2-windows-x64.tar.bz2	
 wxwidgets-3.2.10-windows-x64.tar.bz2
 gettext-0.19.8-windows-x64.tar.bz2
-openssl-3.0.20-windows-x64.tar.bz2
+openssl-3.0.21-windows-x64.tar.bz2

--- a/server/version.txt
+++ b/server/version.txt
@@ -1,6 +1,6 @@
 pg_major_version=16
 pg_minor_version=14
-package_revision=1
+package_revision=2
 pgadmin4=9.15
 languagepack=4.7-1
 stackbuilder=4.2.2

--- a/versions.sh
+++ b/versions.sh
@@ -16,7 +16,7 @@ PG_BUILDNUM_LANGUAGEPACK=1
 #                     Minor version is revision.build.
 
 PG_MAJOR_VERSION=16
-PG_MINOR_VERSION=14.1
+PG_MINOR_VERSION=14.2
 
 # Other package versions
 PG_VERSION_POSTGIS=3.5.6


### PR DESCRIPTION
Off-cycle release for v16 to update the OpenSSL version.