### PR TITLE
Off-cycle release for v14 to update the OpenSSL version

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,10 @@
+# PostgreSQL installer release 14.23-2 (2026-06-11)
+## Changes 🛠️
+- **Dependencies (macOS & Windows)**
+    - Update `openssl` version to `1.1.1zh`
+
+-------------------------------------------------------------------------------------------------------------------------------
+
 # PostgreSQL installer release 14.23-1 (2026-05-14)
 ## Changes 🛠️
 - Update `pgAdmin4` to version `9.15`

--- a/server/packages-win64.txt
+++ b/server/packages-win64.txt
@@ -8,4 +8,4 @@ icu-67-1-windows-x64.tar.bz2
 uuid-1.6.2-windows-x64.tar.bz2	
 wxwidgets-3.2.10-windows-x64.tar.bz2
 gettext-0.19.8-windows-x64.tar.bz2
-openssl-1.1.1zg-windows-x64.tar.bz2
+openssl-1.1.1zh-windows-x64.tar.bz2

--- a/server/version.txt
+++ b/server/version.txt
@@ -1,6 +1,6 @@
 pg_major_version=14
 pg_minor_version=23
-package_revision=1
+package_revision=2
 pgadmin4=9.15
 languagepack=2.9-1
 stackbuilder=4.2.2

--- a/versions.sh
+++ b/versions.sh
@@ -16,7 +16,7 @@ PG_BUILDNUM_LANGUAGEPACK=1
 #                     Minor version is revision.build.
 
 PG_MAJOR_VERSION=14
-PG_MINOR_VERSION=23.1
+PG_MINOR_VERSION=23.2
 
 # Other package versions
 PG_VERSION_POSTGIS=3.5.6


### PR DESCRIPTION
Off-cycle release for v14 to update the OpenSSL version.