### PR TITLE
update generate-sources.sh to handle both git checkout and URL download

### DIFF
--- a/server/generate-sources.sh
+++ b/server/generate-sources.sh
@@ -3,7 +3,7 @@ set -xeu
 NAME=postgresql
 : ${VERSION:?The VERSION environment variable is required}
 WORKDIR=$(pwd)
-TARNAME="${NAME}-${SOURCE_VERSION}"
+TARNAME="${NAME}-${VERSION}"
 cd ${WORKDIR}
 
 if [ -n "${URL:-}" ]; then

--- a/server/generate-sources.sh
+++ b/server/generate-sources.sh
@@ -1,10 +1,12 @@
 #! /bin/sh
-set -xeu
+set -xe
 NAME=postgresql
 : ${VERSION:?The VERSION environment variable is required}
+: ${EXTRA_VERSION:?The EXTRA_VERSION environment variable is required}
+
+CONF_ARGS="--without-icu --without-readline"
 WORKDIR=$(pwd)
-TARNAME="${NAME}-${VERSION}"
-cd ${WORKDIR}
+TARNAME="${NAME}-${VERSION}.${EXTRA_VERSION}"
 
 if [ -n "${URL:-}" ]; then
   # release case: download tarball from URL
@@ -14,9 +16,20 @@ if [ -n "${URL:-}" ]; then
   echo "Tarball md5sum: $(md5sum ${TARNAME}.tar.bz2)"
   md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
 else
-  # snapshot case: create tarball from git checkout
+  # snapshot case: build docs and create tarball
   echo "Source commit hash: $(git -C src rev-parse HEAD)"
   echo "Source branch/ref: $(git -C src rev-parse --abbrev-ref HEAD)"
+
+  # install doc build dependencies
+  sudo apt-get install -y docbook-xsl docbook-xml xsltproc libxml2-utils
+
+  # build HTML docs
+  cd src
+  ./configure $CONF_ARGS
+  make -C doc/src/sgml html
+  cd ${WORKDIR}
+
+  # create tarball
   cp -r src/ "${TARNAME}"
   tar -cjf "${TARNAME}.tar.bz2" "${TARNAME}/"
   echo "Tarball created: ${TARNAME}.tar.bz2"

--- a/server/generate-sources.sh
+++ b/server/generate-sources.sh
@@ -1,14 +1,26 @@
 #! /bin/sh
-
 set -xeu
-
 NAME=postgresql
-
-: ${VERSION:?The VERSION environment variable is required}
-
-WORKDIR=$(pwd)/src
+: ${SOURCE_VERSION:?The SOURCE_VERSION environment variable is required}
+WORKDIR=$(pwd)
+TARNAME="${NAME}-${SOURCE_VERSION}"
 cd ${WORKDIR}
-TARNAME="${NAME}-${VERSION}.${EXTRA_VERSION:-}"
-wget -O "${TARNAME}.tar.bz2" ${URL}
-md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
-mv ${TARNAME}.tar.bz2 ../
+
+if [ -n "${URL:-}" ]; then
+  # release case: download tarball from URL
+  echo "Downloading source tarball from: ${URL}"
+  wget -O "${TARNAME}.tar.bz2" ${URL}
+  echo "Tarball downloaded: ${TARNAME}.tar.bz2"
+  echo "Tarball md5sum: $(md5sum ${TARNAME}.tar.bz2)"
+  md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
+else
+  # snapshot case: create tarball from git checkout
+  echo "Source commit hash: $(git -C src rev-parse HEAD)"
+  echo "Source branch/ref: $(git -C src rev-parse --abbrev-ref HEAD)"
+  cp -r src/ "${TARNAME}"
+  tar -cjf "${TARNAME}.tar.bz2" "${TARNAME}/"
+  echo "Tarball created: ${TARNAME}.tar.bz2"
+  echo "Tarball md5sum: $(md5sum ${TARNAME}.tar.bz2)"
+  md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
+  rm -rf "${TARNAME}"
+fi

--- a/server/generate-sources.sh
+++ b/server/generate-sources.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 set -xeu
 NAME=postgresql
-: ${SOURCE_VERSION:?The SOURCE_VERSION environment variable is required}
+: ${VERSION:?The VERSION environment variable is required}
 WORKDIR=$(pwd)
 TARNAME="${NAME}-${SOURCE_VERSION}"
 cd ${WORKDIR}


### PR DESCRIPTION
Updated generate-sources.sh to handle both git checkout and URL download cases based on the maturity level.

- For snapshot maturity, creates tarball from checked out git source code and logs the commit hash and branch/ref.
- For release maturity, downloads tarball directly from the provided URL and logs the download URL and md5sum.
- Since the official PostgreSQL source does not ship pre-built HTML documentation, the workflow additionally builds the HTML docs before packaging, so the generated docs are included in the build.