### PR TITLE
update generate-sources.sh to handle both git checkout and URL download

### DIFF
--- a/server/generate-sources.sh
+++ b/server/generate-sources.sh
@@ -1,14 +1,26 @@
 #! /bin/sh
-
 set -xeu
-
 NAME=postgresql
-
 : ${SOURCE_VERSION:?The SOURCE_VERSION environment variable is required}
-
-WORKDIR=$(pwd)/src
-cd ${WORKDIR}
+WORKDIR=$(pwd)
 TARNAME="${NAME}-${SOURCE_VERSION}"
-wget -O "${TARNAME}.tar.bz2" ${URL}
-md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
-mv ${TARNAME}.tar.bz2 ../
+cd ${WORKDIR}
+
+if [ -n "${URL:-}" ]; then
+  # release case: download tarball from URL
+  echo "Downloading source tarball from: ${URL}"
+  wget -O "${TARNAME}.tar.bz2" ${URL}
+  echo "Tarball downloaded: ${TARNAME}.tar.bz2"
+  echo "Tarball md5sum: $(md5sum ${TARNAME}.tar.bz2)"
+  md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
+else
+  # snapshot case: create tarball from git checkout
+  echo "Source commit hash: $(git -C src rev-parse HEAD)"
+  echo "Source branch/ref: $(git -C src rev-parse --abbrev-ref HEAD)"
+  cp -r src/ "${TARNAME}"
+  tar -cjf "${TARNAME}.tar.bz2" "${TARNAME}/"
+  echo "Tarball created: ${TARNAME}.tar.bz2"
+  echo "Tarball md5sum: $(md5sum ${TARNAME}.tar.bz2)"
+  md5sum "${TARNAME}.tar.bz2" > "${TARNAME}.tar.bz2.md5"
+  rm -rf "${TARNAME}"
+fi

--- a/server/packages-win64.txt
+++ b/server/packages-win64.txt
@@ -1,4 +1,4 @@
-curl-8.21.0-windows-x64.tar.bz2
+curl-8.20.0-windows-x64.tar.bz2
 zstd-1.5.7-windows-x64.tar.bz2
 lz4-1.10.0-windows-x64.tar.bz2
 libxml2-2.15.3-1-windows-x64.tar.bz2

--- a/server/packages-win64.txt
+++ b/server/packages-win64.txt
@@ -1,4 +1,4 @@
-curl-8.20.0-windows-x64.tar.bz2
+curl-8.21.0-windows-x64.tar.bz2
 zstd-1.5.7-windows-x64.tar.bz2
 lz4-1.10.0-windows-x64.tar.bz2
 libxml2-2.15.3-1-windows-x64.tar.bz2


### PR DESCRIPTION
Updated generate-sources.sh to handle both git checkout and URL download cases based on the maturity level.

For snapshot maturity creates tarball from checked out git source code and logs the commit hash and branch/ref

For release maturity downloads tarball directly from the provided URL and logs the download URL and md5sum