### PR TITLE
Make changes to macOS build environment to support GitHub Actions

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,14 @@
+# PostgreSQL installer release 18.6-1 (2026-08-13)
+## Changes 🛠️
+- Update `pgAdmin4` to version `9.17`
+
+- **Dependencies (macOS & Windows)**
+    - Update `wxwidgets` to version `3.2.11`
+    - Update `curl` to version `8.21.0`
+    - Update `libiconv` to version `1.19`
+
+-------------------------------------------------------------------------------------------------------------------------------
+
 # PostgreSQL installer release 18.4-2 (2026-06-11)
 ## Changes 🛠️
 - **Dependencies (macOS & Windows)**

--- a/server/packages-win64.txt
+++ b/server/packages-win64.txt
@@ -3,10 +3,10 @@ zstd-1.5.7-windows-x64.tar.bz2
 lz4-1.10.0-windows-x64.tar.bz2
 libxml2-2.15.3-1-windows-x64.tar.bz2
 libxslt-1.1.45-1-windows-x64.tar.bz2
-iconv-1.18-windows-x64.tar.bz2
+iconv-1.19-windows-x64.tar.bz2
 zlib-1.3.2-windows-x64.tar.bz2
 icu-77-1-windows-x64.tar.bz2
 uuid-1.6.2-windows-x64.tar.bz2	
-wxwidgets-3.2.10-windows-x64.tar.bz2
+wxwidgets-3.2.11-windows-x64.tar.bz2
 gettext-0.19.8-windows-x64.tar.bz2
 openssl-3.5.7-windows-x64.tar.bz2

--- a/server/scripts/windows/compile.ps1
+++ b/server/scripts/windows/compile.ps1
@@ -204,14 +204,14 @@ Copy-Item $gettext_directory/bin/libwinpthread-1.dll $installation_directory\bin
 Copy-Item $zlib_directory/bin/*.dll $installation_directory\bin
 Copy-Item $zstd_directory/bin/*.dll $installation_directory\bin
 Copy-Item $lz4_directory/bin/*.dll $installation_directory\bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxbase3210u_net_vc_x64_custom.dll $installation_directory/bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxbase3210u_vc_x64_custom.dll $installation_directory/bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxbase3210u_xml_vc_x64_custom.dll $installation_directory/bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3210u_adv_vc_x64_custom.dll $installation_directory/bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3210u_aui_vc_x64_custom.dll $installation_directory/bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3210u_core_vc_x64_custom.dll $installation_directory/bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3210u_html_vc_x64_custom.dll $installation_directory/bin
-Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3210u_xrc_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxbase3211u_net_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxbase3211u_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxbase3211u_xml_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3211u_adv_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3211u_aui_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3211u_core_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3211u_html_vc_x64_custom.dll $installation_directory/bin
+Copy-Item $wxwidgets_directory/lib/vc_x64_dll/wxmsw3211u_xrc_vc_x64_custom.dll $installation_directory/bin
 
 # Manually copy some libraries to the installation directory
 Copy-Item $lz4_directory/lib/liblz4.lib $installation_directory\lib

--- a/server/version.txt
+++ b/server/version.txt
@@ -1,9 +1,9 @@
 pg_major_version=18
-pg_minor_version=4
-package_revision=2
-pgadmin4=9.15
-python=3.13.12
-perl=5.42.0.1
+pg_minor_version=6
+package_revision=1
+pgadmin4=9.17
+python=3.13.15
+perl=5.42.2.1
 pkg-config=0.28-1
-tcl=8.6.17
+tcl=8.6.18
 stackbuilder=4.2.2


### PR DESCRIPTION
Historically, the build-osx.sh script was responsible to prepare the
build environment, to compile the source code and to generate the BitRock
based installer. This is now changed to using a GitHub Actions based
workflow and the supporting shell scripts. The workflow resides in a
separate repository whereas the build scripts and installer code resides
in this repository.

Summary of the Changes:

add new scripts: compile.sh (build PostgreSQL as a universal x86_64 +
arm64 binary), prepare-staging-directory.sh (assemble the InstallBuilder
staging tree), rewrite-dylib-refs.sh (make the build relocatable via
@rpath) and create-debug-symbols.sh (extract dSYM debug symbols).
packages-osx.txt contains 3rd party libs name and versions.
additional fixes required in staging for macOS.

The legacy build-osx.sh and its helper scripts are retained for now, their removal will be done in a separate commit.

Kritika Agarwal, --Tested by Kritika Agarwal --Reviewed by Sandeep Thakkar
DBP-1860