### PR TITLE
macOS: Update rewrite-dylib-refs.sh script to remove stale absolute path from shipped binaries

### DIFF
--- a/server/installer.xml.in
+++ b/server/installer.xml.in
@@ -1387,13 +1387,6 @@ EOF
 
          <actionGroup>
             <actionList>
-                <!-- CI artifacts strip the exec bit; force it before running. -->
-                <changePermissions permissions="0755" files="${system_temp_directory}/postgresql_installer_${random_number}/prerun_checks.sh">
-                    <abortOnError>0</abortOnError>
-                    <ruleList>
-                        <compareText logic="does_not_equal" text="${platform_name}" value="windows"/>
-                    </ruleList>
-                </changePermissions>
                 <runProgram program="${system_temp_directory}/postgresql_installer_${random_number}/prerun_checks.sh">
                     <ruleList>
                         <compareText logic="does_not_equal" text="${platform_name}" value="windows"/>
@@ -2939,9 +2932,6 @@ ${dbsummary}${cltsummary}${sbsummary}${msg(summary.installation.logfile)}: ${Ins
                             </ruleList>
                         </runProgram>
 
-                        <changePermissions permissions="0755" files="${system_temp_directory}/postgresql_installer_${random_number}/runpgcontroldata.sh">
-                            <abortOnError>0</abortOnError>
-                        </changePermissions>
                         <runProgram>
                             <program>${system_temp_directory}/postgresql_installer_${random_number}/runpgcontroldata.sh</program>
                             <programArguments>${system_temp_directory}/postgresql_installer_${random_number} "${datadir}"</programArguments>

--- a/server/packages-osx.txt
+++ b/server/packages-osx.txt
@@ -11,4 +11,3 @@ gettext-0.26-osx.tar.bz2
 e2fsprogs-1.47.4-osx.tar.bz2
 krb5-1.22.2-osx.tar.bz2
 libedit-20260512-3.1-osx.tar.bz2
-libpng-1.6.58-osx.tar.bz2

--- a/server/pgserver.xml.in
+++ b/server/pgserver.xml.in
@@ -1873,9 +1873,6 @@
                     </ruleList>
                 </runProgram>
 
-                <changePermissions permissions="0755" files="${system_temp_directory}/postgresql_installer_${random_number}/runpgcontroldata.sh">
-                    <abortOnError>0</abortOnError>
-                </changePermissions>
                 <runProgram>
                     <program>${system_temp_directory}/postgresql_installer_${random_number}/runpgcontroldata.sh</program>
                     <programArguments>${system_temp_directory}/postgresql_installer_${random_number} "${datadir}"</programArguments>
@@ -2038,13 +2035,6 @@
                     </ruleList>
                 </addChoiceOptions>
 
-                <!-- CI artifacts strip the exec bit; force it before running. -->
-                <changePermissions permissions="0755" files="${system_temp_directory}/postgresql_installer_${random_number}/getlocales">
-                    <abortOnError>0</abortOnError>
-                    <ruleList>
-                        <compareText logic="does_not_equal" text="${platform_name}" value="windows"/>
-                    </ruleList>
-                </changePermissions>
                 <runProgram program="${system_temp_directory}/postgresql_installer_${random_number}/getlocales">
                     <ruleList>
                         <compareText logic="does_not_equal" text="${platform_name}" value="windows"/>
@@ -2646,18 +2636,6 @@
 
     <!-- Postinstallation actions -->
     <postInstallationActionList>
-        <!-- The PostgreSQL binaries (bin/initdb, bin/postgres, ...) and the
-             bundled unix install scripts (createuser.sh, initcluster.sh,
-             loadmodules.sh, createshortcuts*.sh, install-pgadmin.sh, runpsql.sh)
-             must be executable. GitHub CI artifacts strip the exec bit during
-             packaging, so force it here before any of them run (initcluster.sh
-             below execs bin/initdb). -->
-        <changePermissions permissions="0755" files="${installdir}/bin/*;${installdir}/installer/server/*.sh;${installdir}/scripts/*.sh">
-            <abortOnError>0</abortOnError>
-            <ruleList>
-                <compareText logic="does_not_equal" text="${platform_name}" value="windows"/>
-            </ruleList>
-        </changePermissions>
         <!-- WINDOWS :: This files belongs to command line tools, so server should not remove this files -->
         <removeFilesFromUninstaller>
             <files>${installdir}/bin/ssleay32.dll;${installdir}/bin/libeay32.dll;${installdir}/bin/libiconv-2.dll;${installdir}/bin/libintl-9.dll</files>

--- a/server/scripts/osx/prepare-staging-directory.sh
+++ b/server/scripts/osx/prepare-staging-directory.sh
@@ -61,8 +61,8 @@ chmod ugo+x "$PGSERVER/installer/prerun_checks.sh" "$PGSERVER/installer/server/"
 mkdir -p "$PGSERVER/scripts/images"
 cp "$RES/pg-help.icns"   "$PGSERVER/scripts/images/"
 cp "$RES/pg-reload.icns" "$PGSERVER/scripts/images/"
-for a in doc-installationnotes doc-postgresql doc-postgresql-releasenotes doc-pgadmin \
-         psql reload pgadmin stackbuilder; do
+for a in doc-installationnotes doc-postgresql doc-postgresql-releasenotes \
+         psql reload stackbuilder; do
   cp "$OSX_SCRIPTS/$a.applescript.in" "$PGSERVER/scripts/$a.applescript"
 done
 
@@ -83,12 +83,12 @@ cp "$OSX_SCRIPTS/createshortcuts_sb.sh" "$SB/installer/server/createshortcuts_sb
 cp "$RES/pg-stackbuilder.icns"          "$SB/scripts/images/"
 chmod ugo+x "$SB/installer/server/createshortcuts_sb.sh"
 if [ -d stackbuilder.app ]; then
-  cp -pR stackbuilder.app "$SB/stackbuilder.app"
-elif [ -d SB/stackbuilder.app ]; then
-  cp -pR SB/stackbuilder.app "$SB/stackbuilder.app"
-else
-  echo "WARNING: stackbuilder.app not found - stackbuilder component will be incomplete"
-fi
+   # ditto (not cp -R) preserves resource forks/xattrs and the code-signing
+   # seal on the bundle's loose top-level files; cp -R can silently drop them.
+   ditto stackbuilder.app "$SB/stackbuilder.app"
+ else
+   echo "WARNING: stackbuilder.app not found - stackbuilder component will be incomplete"
+ fi
 
 # ---------------------------------------------------------------------------
 # Installer-level assets: side/splash images, i18n language files and the
@@ -98,8 +98,6 @@ mkdir -p "$S/resources" "$S/scripts"
 cp packaging-config/resources/pg-side.png   "$S/resources/"
 cp packaging-config/resources/pg-splash.png "$S/resources/"
 cp -r packaging-config/server/i18n "$S/"
-cp packaging-config/scripts/determineLinuxInitSystem.xml "$S/scripts/"
-cp packaging-config/scripts/linuxServiceAction.xml       "$S/scripts/"
 
 # ---------------------------------------------------------------------------
 # InstallBuilder project files (templated by the workflow's Pre-installer step)
@@ -107,7 +105,6 @@ cp packaging-config/scripts/linuxServiceAction.xml       "$S/scripts/"
 cp packaging-config/server/installer.xml.in        "$S/installer.xml"
 cp packaging-config/server/pgserver.xml.in         "$S/pgserver-osx.xml"
 cp packaging-config/server/commandlinetools.xml.in "$S/commandlinetools-osx.xml"
-
 cp packaging-config/server/stackbuilder.xml.in "$S/stackbuilder-osx.xml"
 
 echo "--- staging/osx contents ---"

--- a/server/scripts/osx/prepare-staging-directory.sh
+++ b/server/scripts/osx/prepare-staging-directory.sh
@@ -98,6 +98,8 @@ mkdir -p "$S/resources" "$S/scripts"
 cp packaging-config/resources/pg-side.png   "$S/resources/"
 cp packaging-config/resources/pg-splash.png "$S/resources/"
 cp -r packaging-config/server/i18n "$S/"
+cp packaging-config/scripts/determineLinuxInitSystem.xml "$S/scripts/"
+cp packaging-config/scripts/linuxServiceAction.xml       "$S/scripts/"
 
 # ---------------------------------------------------------------------------
 # InstallBuilder project files (templated by the workflow's Pre-installer step)

--- a/server/scripts/osx/rewrite-dylib-refs.sh
+++ b/server/scripts/osx/rewrite-dylib-refs.sh
@@ -4,7 +4,8 @@ set -e
 PREFIX="${1:?usage: rewrite-dylib-refs.sh <prefix> [extra_build_lib_dir ...]}"
 shift || true
 
-BUILD_LIB_DIRS="$PREFIX/lib $*"
+EXTRA_BUILD_LIB_DIRS="$*"
+BUILD_LIB_DIRS="$PREFIX/lib $EXTRA_BUILD_LIB_DIRS"
 
 _reloc() {
     f="$1"; rpath="$2"
@@ -17,6 +18,19 @@ _reloc() {
     if ! otool -l "$f" | grep -A2 LC_RPATH | grep -q "path $rpath "; then
         install_name_tool -add_rpath "$rpath" "$f"
     fi
+
+    # Drop any stale absolute rpath pointing at an ephemeral build-time
+    # dependency dir (e.g. $DEP_PREFIX/lib on the CI runner, passed in as an
+    # extra_build_lib_dir arg). It's dead weight now that the relative
+    # @loader_path rpath above is in place - dyld just skips it since it
+    # never resolves on any other machine - but leaving it means shipped
+    # binaries carry a dangling reference to a path that only ever existed
+    # on the build runner.
+    for bp in $EXTRA_BUILD_LIB_DIRS; do
+        if otool -l "$f" | grep -A2 LC_RPATH | grep -q "path $bp "; then
+            install_name_tool -delete_rpath "$bp" "$f" || true
+        fi
+    done
 
     # 2. normalise a dylib/bundle's own install id
     if file "$f" | grep -qE "shared library|bundle"; then


### PR DESCRIPTION
- Remove the unwanted change that were added in XML files as part of migrating to GH actions

Kritika Agarwal