### PR TITLE
macOS: link plpython3 against python.org's Python.framework via Versions/Current

### DIFF
--- a/server/packages-osx.txt
+++ b/server/packages-osx.txt
@@ -7,7 +7,7 @@ libxml2-2.15.3-osx.tar.bz2
 libxslt-1.1.45-osx.tar.bz2
 libiconv-1.19-osx.tar.bz2
 icu-77.1-osx.tar.bz2
-gettext-0.26-osx.tar.bz2
+gettext-1.0-osx.tar.bz2
 e2fsprogs-1.47.4-osx.tar.bz2
 krb5-1.22.2-osx.tar.bz2
 libedit-20260512-3.1-osx.tar.bz2

--- a/server/packages-osx.txt
+++ b/server/packages-osx.txt
@@ -6,7 +6,7 @@ lz4-1.10.0-osx.tar.bz2
 libxml2-2.15.3-osx.tar.bz2
 libxslt-1.1.45-osx.tar.bz2
 libiconv-1.19-osx.tar.bz2
-icu-77.1-osx.tar.bz2
+icu-78.3-osx.tar.bz2
 gettext-1.0-osx.tar.bz2
 e2fsprogs-1.47.4-osx.tar.bz2
 krb5-1.22.2-osx.tar.bz2

--- a/server/packages-osx.txt
+++ b/server/packages-osx.txt
@@ -6,8 +6,8 @@ lz4-1.10.0-osx.tar.bz2
 libxml2-2.15.3-osx.tar.bz2
 libxslt-1.1.45-osx.tar.bz2
 libiconv-1.19-osx.tar.bz2
-icu-78.3-osx.tar.bz2
-gettext-1.0-osx.tar.bz2
+icu-77.1-osx.tar.bz2
+gettext-0.26-osx.tar.bz2
 e2fsprogs-1.47.4-osx.tar.bz2
 krb5-1.22.2-osx.tar.bz2
 libedit-20260512-3.1-osx.tar.bz2

--- a/server/scripts/osx/compile.sh
+++ b/server/scripts/osx/compile.sh
@@ -5,9 +5,10 @@ set -xe
 
 SOURCE_DIR="$1"
 DEP_PREFIX="$2"
+PYTHON_FRAMEWORK="$3"
 
-if [ -z "$SOURCE_DIR" ] || [ -z "$DEP_PREFIX" ]; then
-    echo "Usage: $0 <source_directory> <dep_prefix>"
+if [ -z "$SOURCE_DIR" ] || [ -z "$DEP_PREFIX" ] || [ -z "$PYTHON_FRAMEWORK" ]; then
+    echo "Usage: $0 <source_directory> <dep_prefix> <python_framework_dir>"
     exit 1
 fi
 export PATH="$DEP_PREFIX/bin:$PATH"
@@ -17,6 +18,7 @@ cd "$SOURCE_DIR"
 
 DYLD_LIBRARY_PATH="$DEP_PREFIX/lib" \
 PG_SYSROOT="$PG_SYSROOT" \
+PYTHON="$PYTHON_FRAMEWORK/Versions/Current/bin/python3" \
 LDFLAGS="-L$DEP_PREFIX/lib -Wl,-headerpad_max_install_names" \
 CFLAGS="$PG_ARCH_OSX_CFLAGS -O2" \
 XML2_CONFIG="$DEP_PREFIX/bin/xml2-config" \
@@ -35,6 +37,7 @@ LIBCURL_LIBS="-L$DEP_PREFIX/lib" \
    --enable-debug \
    --with-ldap \
    --with-openssl \
+   --with-python \
    --with-bonjour \
    --with-pam \
    --with-libxml \
@@ -49,6 +52,17 @@ LIBCURL_LIBS="-L$DEP_PREFIX/lib" \
 
 make -j"$(sysctl -n hw.ncpu)"
 make install
+
+# sysconfig reports the concrete version path, not Current, so plpython3
+# links against a fixed Python version by default. Repoint it at Current so
+# any python.org install >=3.9 on the end user's Mac satisfies it.
+PLPY="$PG_STAGING/lib/postgresql/plpython3.dylib"
+if [ -f "$PLPY" ]; then
+    OLD_DEP=$(otool -L "$PLPY" | awk 'NR>1{print $1}' | grep -m1 'Python.framework')
+    [ -n "$OLD_DEP" ] || { echo "ERROR: no Python.framework dependency in plpython3.dylib"; exit 1; }
+    NEW_DEP="$PYTHON_FRAMEWORK/Versions/Current/${OLD_DEP#*Python.framework/Versions/*/}"
+    install_name_tool -change "$OLD_DEP" "$NEW_DEP" "$PLPY"
+fi
 
 #build postgres docs
 cd doc

--- a/server/scripts/osx/compile.sh
+++ b/server/scripts/osx/compile.sh
@@ -65,8 +65,14 @@ make install
 PLPY="$PG_STAGING/lib/postgresql/plpython3.dylib"
 if [ -f "$PLPY" ]; then
     OLD_DEP=$(otool -L "$PLPY" | awk 'NR>1{print $1}' | grep -m1 'Python.framework')
-    [ -n "$OLD_DEP" ] || { echo "ERROR: no Python.framework dependency in plpython3.dylib"; exit 1; }
-    NEW_DEP="$PYTHON_FRAMEWORK/Versions/Current/${OLD_DEP#*Python.framework/Versions/*/}"
+    if [ -z "$OLD_DEP" ]; then
+        echo "ERROR: no Python.framework dependency in plpython3.dylib"
+        exit 1
+    fi
+
+    # Replace whatever version folder is there (e.g. "3.14") with "Current"
+    NEW_DEP=$(echo "$OLD_DEP" | sed -E 's#/Versions/[^/]+/#/Versions/Current/#')
+
     install_name_tool -change "$OLD_DEP" "$NEW_DEP" "$PLPY"
 fi
 

--- a/server/scripts/osx/compile.sh
+++ b/server/scripts/osx/compile.sh
@@ -6,9 +6,11 @@ set -xe
 SOURCE_DIR="$1"
 DEP_PREFIX="$2"
 PYTHON_FRAMEWORK="$3"
+PERL_DIR="$4"
+TCL_DIR="$5"
 
-if [ -z "$SOURCE_DIR" ] || [ -z "$DEP_PREFIX" ] || [ -z "$PYTHON_FRAMEWORK" ]; then
-    echo "Usage: $0 <source_directory> <dep_prefix> <python_framework_dir>"
+if [ -z "$SOURCE_DIR" ] || [ -z "$DEP_PREFIX" ] || [ -z "$PYTHON_FRAMEWORK" ] || [ -z "$PERL_DIR" ] || [ -z "$TCL_DIR" ]; then
+    echo "Usage: $0 <source_directory> <dep_prefix> <python_framework_dir> <perl_dir> <tcl_dir>"
     exit 1
 fi
 export PATH="$DEP_PREFIX/bin:$PATH"
@@ -19,6 +21,8 @@ cd "$SOURCE_DIR"
 DYLD_LIBRARY_PATH="$DEP_PREFIX/lib" \
 PG_SYSROOT="$PG_SYSROOT" \
 PYTHON="$PYTHON_FRAMEWORK/Versions/Current/bin/python3" \
+PERL="$PERL_DIR/bin/perl" \
+TCL_CONFIG_SH="$TCL_DIR/lib/tclConfig.sh" \
 LDFLAGS="-L$DEP_PREFIX/lib -Wl,-headerpad_max_install_names" \
 CFLAGS="$PG_ARCH_OSX_CFLAGS -O2" \
 XML2_CONFIG="$DEP_PREFIX/bin/xml2-config" \
@@ -38,6 +42,8 @@ LIBCURL_LIBS="-L$DEP_PREFIX/lib" \
    --with-ldap \
    --with-openssl \
    --with-python \
+   --with-perl \
+   --with-tcl \
    --with-bonjour \
    --with-pam \
    --with-libxml \

--- a/server/version.txt
+++ b/server/version.txt
@@ -1,6 +1,7 @@
 pg_major_version=19
 pg_minor_version=0
 package_revision=beta3
+languagepack=7.0-1
 python=3.14.7
 perl=5.42.2.1
 pkg-config=0.28-1


### PR DESCRIPTION
PG19 builds plpython3 against Python's stable/Limited API, so it doesn't
need to be tied to one exact Python minor version at runtime. Wire
compile.sh to build against a python.org framework install (passed in as
a new PYTHON_FRAMEWORK arg) instead of a LanguagePack-bundled Python:

- --with-python, PYTHON=$PYTHON_FRAMEWORK/Versions/Current/bin/python3
- after install, repoint plpython3.dylib's Python.framework dependency
  from the concrete version path sysconfig reports (e.g.
  Versions/3.14/Python) to Versions/Current/Python - sysconfig never
  resolves through the Current symlink on its own, so this rewrite is
  what actually makes version-independence work

Result: any python.org install >=3.9 on the end user's Mac satisfies
plpython3 at runtime, regardless of which Python version was present
on the build machine.

Also in this commit:
- Bump ICU to 78.3 and gettext to 1.0 in packages-osx.txt.
- Add LanguagePack 7.0.1, scoped exclusively to fat/universal builds
  of Perl and Tcl - LP no longer bundles Python (superseded by the
  python.org framework linking above).

Kritika Agarwal
DBP-2217